### PR TITLE
Handle binlog_checksum variable missing in MySQL < 5.6.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ ZongJi.prototype._isChecksumEnabled = function(next) {
 
   ctrlConnection.query(sql, function(err, rows) {
     if (err) {
+      if(err.toString().match(/ER_UNKNOWN_SYSTEM_VARIABLE/)){
+        // MySQL < 5.6.2 does not support @@GLOBAL.binlog_checksum
+        return next(false);
+      }
       throw err;
     }
 


### PR DESCRIPTION
Hello,

I have run into an issue using MySQL 5.5.40 on Ubuntu 14.04.1. The MySQL global variable `@@GLOBAL.binlog_checksum` does not exist. With this patch, the process runs properly.

This only seems to be effecting the `master` branch. The published NPM package 0.2.0 seems to work fine. I was evaluating the package by cloning it and encountered this but now that I am using `npm install` the error does not occur.

Thanks for the awesome package!
