### PR TITLE
Fix test case "type_temporal_other" failed on non-UTC Mysql server.

### DIFF
--- a/test/types.js
+++ b/test/types.js
@@ -54,8 +54,10 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion){
       querySequence(conn.db, [
         'DROP TABLE IF EXISTS ' + conn.escId(testTable),
         'CREATE TABLE ' + conn.escId(testTable) + ' (' + fieldText + ')',
+        'SET @@session.time_zone = "+00:00"',
         'INSERT INTO ' + conn.escId(testTable) +
           ' (' + insertColumns + ') VALUES ' + insertRows,
+        'SET @@session.time_zone = "SYSTEM"',
         'SELECT * FROM ' + conn.escId(testTable)
       ], function(results){
         var selectResult = results[results.length - 1];


### PR DESCRIPTION
The timestamp value "1970-01-01 00:00:01" will be out of range on non-UTC Mysql Server.
On Mysql, the minimum timestamp value is <<<UTC>>> "1970-01-01 00:00:01". So if the timezone of our Mysql server is "Asia/Shanghai", the minimum value should be "1970-01-01 08:00:01" in fact.