### PR TITLE
stop() method now kills binlog connection

### DIFF
--- a/example.js
+++ b/example.js
@@ -18,5 +18,6 @@ zongji.start({
 
 process.on('SIGINT', function() {
   console.log('Got SIGINT.');
+  zongji.stop();
   process.exit();
 });

--- a/index.js
+++ b/index.js
@@ -202,8 +202,14 @@ ZongJi.prototype.start = function(options) {
 
 ZongJi.prototype.stop = function(){
   var self = this;
+  // Binary log connection does not end with destroy()
   self.connection.destroy();
-  self.ctrlConnection.destroy();
+  self.ctrlConnection.query(
+    'KILL ' + self.connection.threadId,
+    function(error, reuslts){
+      self.ctrlConnection.destroy();
+    }
+  );
 };
 
 ZongJi.prototype._skipEvent = function(eventName){

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "nodeunit": "~0.9.0"
   },
   "dependencies": {
-    "mysql": "~2.5.3"
+    "mysql": "~2.5.5"
   }
 }


### PR DESCRIPTION
@nevill It was brought to my attention that the binary log connection is never closed on the server after calling `Zongji.stop()`. This commit fixes the bug. Would you please merge this and release version 0.3.1?

Original issue: https://github.com/numtel/meteor-mysql/issues/7