### PR TITLE
metadata for time with fractional part

### DIFF
--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -231,10 +231,12 @@ TableMap.prototype._readColumnMetadata = function(parser) {
           };
         }
         break;
-	  case 'DATETIME2':
-	    // MySQL bug???
-	    parser.parseUnsignedNumber(1);
-	    break;
+      case 'TIMESTAMP2':
+      case 'DATETIME2':
+        result = {
+          decimals: parser.parseUnsignedNumber(1)
+        };
+        break;
     }
 
     return result;

--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -231,6 +231,10 @@ TableMap.prototype._readColumnMetadata = function(parser) {
           };
         }
         break;
+	  case 'DATETIME2':
+	    // MySQL bug???
+	    parser.parseUnsignedNumber(1);
+	    break;
     }
 
     return result;

--- a/test/types.js
+++ b/test/types.js
@@ -337,3 +337,11 @@ defineTypeTest('text', [
   [null, null, null, null]
 ]);
 
+defineTypeTest('datetime_then_decimal', [
+  'DATETIME(3) NULL',
+  'DECIMAL(30, 10) NULL'
+], [
+  ['"1000-01-01 00:00:00.123"', 10.10],
+  ['"9999-12-31 23:59:59.001"', -123.45],
+  ['"2014-12-27 01:07:08.053"', 12345.123]
+], '5.6.4');


### PR DESCRIPTION
according to https://docs.oracle.com/cd/E17952_01/mysql-5.6-relnotes-en/news-5-6-4.html
"In the MYSQL_FIELD column metadata structure, the decimals member indicates the fractional seconds precision for TIME, DATETIME, and TIMESTAMP columns."
it is added here: https://github.com/mysql/mysql-server/blob/f964f6b37337b98d467c1e9fb7914c1655a08e84/sql/field.h#L2685
for older versions it also works because format is recognized as TIMESTAMP and DATETIME when in newer TIMESTAMP2 and DATETIME2
tested in 5.5.40, 5.6.41 and 5.7.5-m15