### PR TITLE
Catching MySQL errors, and reconnecting to MySQL server

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ function ZongJi(dsn, options) {
 
 //  this.ctrlConnection = mysql.createConnection(ctrlDsn);
 //  this.ctrlConnection.connect();
+  this.interval = null;
+  this.interval2 = null;
+  this.binlogName = null;
+  this.nextPosition = 0;
+  this.listenerAdded = false;
   this._handleDisconnect();
 
   this.ctrlCallbacks = [];
@@ -50,24 +55,62 @@ ZongJi.prototype._handleDisconnect = function() {
     if(err) {
       setTimeout(function() {
           self._handleDisconnect();
-      }.bind(this), 2000);
+      }, 5000);
     } else {
+      if (self.connection && self.connection.state && self.connection.state !== 'disconnected' && self.disconnect()) {
+        self.connection.state = 'disconnected';
+      }
       self.connection = mysql.createConnection(self.dsn);
       if (self.ready && self.ctrlConnection.state==='authenticated' && self.connection.state==='disconnected') {
-       console.log("\n** Reconnecting **\n\n\n\n\n\n\n\n\n\n");
+       console.log("** Reconnected **");
        self._init();
        self.start(self.options);
       }
+      //polling the server to see the connection is active, if error, then the handleDisconnect will kick into action
+      self.interval = setInterval(function(){
+        self.ctrlConnection.query("SELECT 1 AS ctrlConnection", function(err, rows) {
+          if (err) throw err;
+          //console.log(rows);
+        });
+      }, 30000);
     }
   });
 
   self.ctrlConnection.on('error', function(err) {
-    if(err.code === 'PROTOCOL_CONNECTION_LOST' || err.code === 'ECONNREFUSED') {
+    clearInterval(self.interval);
+    if(err.code === 'PROTOCOL_CONNECTION_LOST' || err.code === 'ECONNREFUSED' || err.code === 'ETIMEDOUT') {
       self._handleDisconnect();
     } else {
       throw err;
     }
   });
+};
+
+ZongJi.prototype._handleConnectionDisconnect = function(){
+  var self = this;
+  if (self.connection.threadId !== null) {
+    console.log("self.connection.threadId: "+self.connection.threadId);
+  }
+  if (self.interval2 === null) {
+    console.log("_handleConnectionDisconnect called");
+    var triggerTimeout = (Date.now()/1000|0)+600;
+    self.interval2 = setInterval(function(){
+      if (triggerTimeout < Date.now()/1000|0) {
+        console.log("Triggered Event TimeOut, disconnecting self.connection");
+        self.disconnect()
+      }
+    }, 10000);
+  }
+  if (self.listenerAdded === false) {
+    self.listenerAdded = true;
+    console.log("*******listenerAdded*********");
+    self.on('binlog', function(evt){
+      if (evt.getEventName() !== 'tablemap') {
+        triggerTimeout = (Date.now()/1000|0)+600;
+        console.log("triggerTimeout: " +triggerTimeout+', for the event '+evt.getEventName());
+      }
+    });
+  }
 };
 
 ZongJi.prototype._init = function() {
@@ -204,10 +247,30 @@ ZongJi.prototype.start = function(options) {
 
   var _start = function() {
     self.connection._implyConnect();
+    self._handleConnectionDisconnect();
     self.connection._protocol._enqueue(new self.binlog(function(error, event){
       if(error) return self.emit('error', error);
       // Do not emit events that have been filtered out
       if(event === undefined || event._filtered === true) return;
+
+      //Manage Server Restarts
+      //log gets rotated when mysqld restarts, each new binlogfile starts with position 0
+      // if currently watching binlogName != new binlogName, then it shows server restarted, this is required, because if the script is running and mysqld restarts, the whole events from last file is returned, we need to skip the events that we already processed, we use nextPosition for this purpose.
+      if (event.getTypeName() === 'Rotate') {
+       //console.log("Rotate: \n", event);//{ timestamp: 0,nextPosition: 0,size: 24,position: 4,binlogName: 'mysql-bin.000107' }
+        if (self.binlogName !== event.binlogName) {
+          self.binlogName = event.binlogName;
+          self.nextPosition = 0;
+        }
+      }
+
+      // Skip the processed events
+      if (self.nextPosition >= event.nextPosition) {
+        return;
+      }
+      else {
+        self.nextPosition = event.nextPosition;
+      }
 
       if (event.getTypeName() === 'TableMap') {
         var tableMap = self.tableMap[event.tableId];
@@ -240,15 +303,42 @@ ZongJi.prototype.stop = function(){
   self.connection.destroy();
   self.ctrlConnection.query(
     'KILL ' + self.connection.threadId,
-    function(error, reuslts){
+    function(error, rows){
       self.ctrlConnection.destroy();
     }
   );
 };
 
+ZongJi.prototype.disconnect = function(){
+  var self = this;
+  // Binary log connection does not end with destroy()
+  //self.connection._protocol.quit();
+  self.connection.destroy();
+  self.ctrlConnection.query(
+    'KILL '+self.connection.threadId,
+    function(err, rows){
+      if (err) throw err;
+      console.log('KILLED MySQL self.connection.threadId: ' + self.connection.threadId);
+      self.reconnect();
+    }
+  );
+};
+
+ZongJi.prototype.reconnect = function(){
+  var self =  this;
+  clearInterval(self.interval2);
+  self.interval2 = null;
+  self.connection = mysql.createConnection(self.dsn);
+  self.start(self.options);
+  console.log("Started Again");
+};
+
 ZongJi.prototype._skipEvent = function(eventName){
   var include = this.options.includeEvents;
   var exclude = this.options.excludeEvents;
+  if (include.indexOf('rotate') === -1) {
+    include.push('rotate');
+  }
   return !(
    (include === undefined ||
     (include instanceof Array && include.indexOf(eventName) !== -1)) &&

--- a/index.js
+++ b/index.js
@@ -9,14 +9,10 @@ function ZongJi(dsn, options) {
   EventEmitter.call(this);
 
   // to send table info query
-  this.dsn = dsn;
-
   var ctrlDsn = cloneObjectSimple(dsn);
   ctrlDsn.database = 'information_schema';
+  this.dsn = dsn;
   this.ctrlDsn = ctrlDsn;
-
-//  this.ctrlConnection = mysql.createConnection(ctrlDsn);
-//  this.ctrlConnection.connect();
   this.interval = null;
   this.interval2 = null;
   this.binlogName = null;
@@ -25,9 +21,6 @@ function ZongJi(dsn, options) {
   this._handleDisconnect();
 
   this.ctrlCallbacks = [];
-
-//  this.connection = mysql.createConnection(dsn);
-
   this.tableMap = {};
   this.ready = false;
   this.useChecksum = false;
@@ -62,7 +55,7 @@ ZongJi.prototype._handleDisconnect = function() {
       }
       self.connection = mysql.createConnection(self.dsn);
       if (self.ready && self.ctrlConnection.state==='authenticated' && self.connection.state==='disconnected') {
-       console.log("** Reconnected **");
+      //Reconnected
        self._init();
        self.start(self.options);
       }
@@ -70,7 +63,6 @@ ZongJi.prototype._handleDisconnect = function() {
       self.interval = setInterval(function(){
         self.ctrlConnection.query("SELECT 1 AS ctrlConnection", function(err, rows) {
           if (err) throw err;
-          //console.log(rows);
         });
       }, 30000);
     }
@@ -88,26 +80,21 @@ ZongJi.prototype._handleDisconnect = function() {
 
 ZongJi.prototype._handleConnectionDisconnect = function(){
   var self = this;
-  if (self.connection.threadId !== null) {
-    console.log("self.connection.threadId: "+self.connection.threadId);
-  }
   if (self.interval2 === null) {
-    console.log("_handleConnectionDisconnect called");
     var triggerTimeout = (Date.now()/1000|0)+600;
     self.interval2 = setInterval(function(){
+      //If no activity, Reconnect after every 10mins, to make sure that the connection is alive
       if (triggerTimeout < Date.now()/1000|0) {
-        console.log("Triggered Event TimeOut, disconnecting self.connection");
         self.disconnect()
       }
     }, 10000);
   }
   if (self.listenerAdded === false) {
     self.listenerAdded = true;
-    console.log("*******listenerAdded*********");
     self.on('binlog', function(evt){
       if (evt.getEventName() !== 'tablemap') {
+        //An event occured, increment the 10min timeout value for reconnection
         triggerTimeout = (Date.now()/1000|0)+600;
-        console.log("triggerTimeout: " +triggerTimeout+', for the event '+evt.getEventName());
       }
     });
   }
@@ -257,7 +244,6 @@ ZongJi.prototype.start = function(options) {
       //log gets rotated when mysqld restarts, each new binlogfile starts with position 0
       // if currently watching binlogName != new binlogName, then it shows server restarted, this is required, because if the script is running and mysqld restarts, the whole events from last file is returned, we need to skip the events that we already processed, we use nextPosition for this purpose.
       if (event.getTypeName() === 'Rotate') {
-       //console.log("Rotate: \n", event);//{ timestamp: 0,nextPosition: 0,size: 24,position: 4,binlogName: 'mysql-bin.000107' }
         if (self.binlogName !== event.binlogName) {
           self.binlogName = event.binlogName;
           self.nextPosition = 0;
@@ -312,13 +298,11 @@ ZongJi.prototype.stop = function(){
 ZongJi.prototype.disconnect = function(){
   var self = this;
   // Binary log connection does not end with destroy()
-  //self.connection._protocol.quit();
   self.connection.destroy();
   self.ctrlConnection.query(
     'KILL '+self.connection.threadId,
     function(err, rows){
-      if (err) throw err;
-      console.log('KILLED MySQL self.connection.threadId: ' + self.connection.threadId);
+      //KILLED MySQL self.connection.threadId
       self.reconnect();
     }
   );
@@ -330,13 +314,12 @@ ZongJi.prototype.reconnect = function(){
   self.interval2 = null;
   self.connection = mysql.createConnection(self.dsn);
   self.start(self.options);
-  console.log("Started Again");
 };
 
 ZongJi.prototype._skipEvent = function(eventName){
   var include = this.options.includeEvents;
   var exclude = this.options.excludeEvents;
-  if (include.indexOf('rotate') === -1) {
+  if (Array.isArray(include) && include.indexOf('rotate') === -1) {
     include.push('rotate');
   }
   return !(


### PR DESCRIPTION
Hello nevill,

  Thanks for this nice package.

  Can you please review the code and pull it?

  I have used a handleDisconnect() function to reconnect to MySQL server if a connection error occurs, either due to mysql server restart or network error. handleDisconect() will catch these errors and try to reconnect to server at 2 sec interval, if success it reinitialize zongji and start it again with current options.

  This would be cool feature and make ZongJi more reliable.

ToDo:
1. Track the position of the event that ZongJi has processed, and resume from next event position after re-establishing connection.

I have used ZongJi in a node module that I have to create as part of my work. I have done the error catching and log rotate watching, event tracking in this module, https://github.com/sirhanshafahath/mysql-events/blob/master/index.js

ZongJi would be much better and helpful if you can implement it.

Let me know if this is okay.

Thanks