### PR TITLE
Added Support for JSON Data Type introduced in MySQL 5.7.8

### DIFF
--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -205,6 +205,7 @@ TableMap.prototype._readColumnMetadata = function(parser) {
         break;
       case 'BLOB':
       case 'GEOMETRY':
+      case 'JSON':
         result = {
           'length_size': parser.parseUnsignedNumber(1)
         };

--- a/lib/common.js
+++ b/lib/common.js
@@ -20,6 +20,8 @@ var MysqlTypes = {
   'TIMESTAMP2': 17,
   'DATETIME2': 18,
   'TIME2': 19,
+  // JSON data type added in MySQL 5.7.9
+  'JSON': 245,
   'NEWDECIMAL': 246,
   'ENUM': 247,
   'SET': 248,
@@ -431,6 +433,7 @@ exports.readMysqlValue = function(parser, column, columnSchema) {
     case MysqlTypes.MEDIUM_BLOB:
     case MysqlTypes.LONG_BLOB:
     case MysqlTypes.BLOB:
+    case MysqlTypes.JSON:
       var lengthSize = column.metadata['length_size'];
       result = parser.parseString(
         parser.parseUnsignedNumber(lengthSize));

--- a/lib/common.js
+++ b/lib/common.js
@@ -20,7 +20,7 @@ var MysqlTypes = {
   'TIMESTAMP2': 17,
   'DATETIME2': 18,
   'TIME2': 19,
-  // JSON data type added in MySQL 5.7.9
+  // JSON data type added in MySQL 5.7.7
   'JSON': 245,
   'NEWDECIMAL': 246,
   'ENUM': 247,


### PR DESCRIPTION
The JSON Data Type was introduced in [MySQL 5.7.8](https://dev.mysql.com/doc/refman/5.7/en/json.html)

I have added code to zongji to support it - the changes were very small.

I have tested this using Meteor with [numtel's mysql-live-select](https://github.com/numtel/mysql-live-select) package, which relies on zongji to read the binary log.

For the database, I am using Percona Server 5.7.10-1, which is based on MySQL 5.7.10.