### PR TITLE
0.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,17 @@ ZongJi.prototype._fetchTableInfo = function(tableMapEvent, next) {
     if (err) {
       // Errors should be emitted
       self.emit('error', err);
+      // This is a fatal error, no additional binlog events will be
+      // processed since next() will never be called
+      return;
+    }
+
+    if (rows.length === 0) {
+      self.emit('error', new Error(
+        'Insufficient permissions to access: ' +
+        tableMapEvent.schemaName + '.' + tableMapEvent.tableName));
+      // This is a fatal error, no additional binlog events will be
+      // processed since next() will never be called
       return;
     }
 
@@ -251,8 +262,8 @@ ZongJi.prototype._skipSchema = function(database, table){
       (include[database] instanceof Array &&
        include[database].indexOf(table) !== -1)))) &&
    (exclude === undefined ||
-      (database !== undefined && 
-       (!(database in exclude) || 
+      (database !== undefined &&
+       (!(database in exclude) ||
         (exclude[database] !== true &&
           (exclude[database] instanceof Array &&
            exclude[database].indexOf(table) === -1))))));

--- a/index.js
+++ b/index.js
@@ -12,10 +12,15 @@ function ZongJi(dsn, options) {
   var ctrlDsn = cloneObjectSimple(dsn);
   ctrlDsn.database = 'information_schema';
   this.ctrlConnection = mysql.createConnection(ctrlDsn);
+  this.ctrlConnection.on('error', this._emitError);
+  this.ctrlConnection.on('unhandledError', this._emitError);
+
   this.ctrlConnection.connect();
   this.ctrlCallbacks = [];
 
   this.connection = mysql.createConnection(dsn);
+  this.connection.on('error', this._emitError);
+  this.connection.on('unhandledError', this._emitError);
 
   this.tableMap = {};
   this.ready = false;
@@ -251,6 +256,10 @@ ZongJi.prototype._skipSchema = function(database, table){
         (exclude[database] !== true &&
           (exclude[database] instanceof Array &&
            exclude[database].indexOf(table) === -1))))));
+};
+
+ZongJi.prototype._emitError = function(error) {
+  this.emit('error', error);
 };
 
 module.exports = ZongJi;

--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -174,44 +174,43 @@ TableMap.prototype.updateColumnInfo = function() {
 
 TableMap.prototype._readColumnMetadata = function(parser) {
   this.columnsMetadata = this.columnTypes.map(function(code) {
-    var mysqlType = Common.convertToMysqlType(code);
     var result;
 
     //jshint indent: false
-    switch (mysqlType) {
-      case 'FLOAT':
-      case 'DOUBLE':
+    switch (code) {
+      case Common.MysqlTypes.FLOAT:
+      case Common.MysqlTypes.DOUBLE:
         result = {
           size: parser.parseUnsignedNumber(1)
         };
         break;
-      case 'VARCHAR':
+      case Common.MysqlTypes.VARCHAR:
         result = {
           'max_length': parser.parseUnsignedNumber(2)
         };
         break;
-      case 'BIT':
+      case Common.MysqlTypes.BIT:
         var bits = parser.parseUnsignedNumber(1);
         var bytes = parser.parseUnsignedNumber(1);
         result = {
           bits: bytes * 8 + bits
         };
         break;
-      case 'NEWDECIMAL':
+      case Common.MysqlTypes.NEWDECIMAL:
         result = {
           precision: parser.parseUnsignedNumber(1),
           decimals: parser.parseUnsignedNumber(1),
         };
         break;
-      case 'BLOB':
-      case 'GEOMETRY':
-      case 'JSON':
+      case Common.MysqlTypes.BLOB:
+      case Common.MysqlTypes.GEOMETRY:
+      case Common.MysqlTypes.JSON:
         result = {
           'length_size': parser.parseUnsignedNumber(1)
         };
         break;
-      case 'STRING':
-      case 'VAR_STRING':
+      case Common.MysqlTypes.STRING:
+      case Common.MysqlTypes.VAR_STRING:
         // The STRING type sets a 'real_type' field to indicate the
         // actual type which is fundamentally incompatible with STRING
         // parsing. Setting a 'type' key in this hash will cause
@@ -219,8 +218,8 @@ TableMap.prototype._readColumnMetadata = function(parser) {
         // provided 'type' here.
         var metadata = (parser.parseUnsignedNumber(1) << 8) + parser.parseUnsignedNumber(1);
         var realType = metadata >> 8;
-        var typeName = Common.convertToMysqlType(realType);
-        if (typeName === 'ENUM' || typeName === 'SET') {
+        if (realType === Common.MysqlTypes.ENUM
+            || realType === Common.MysqlTypes.SET) {
           result = {
             type: realType,
             size: metadata & 0x00ff
@@ -232,9 +231,9 @@ TableMap.prototype._readColumnMetadata = function(parser) {
           };
         }
         break;
-      case 'TIMESTAMP2':
-      case 'DATETIME2':
-      case 'TIME2':
+      case Common.MysqlTypes.TIMESTAMP2:
+      case Common.MysqlTypes.DATETIME2:
+      case Common.MysqlTypes.TIME2:
         result = {
           decimals: parser.parseUnsignedNumber(1)
         };

--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -205,6 +205,7 @@ TableMap.prototype._readColumnMetadata = function(parser) {
         break;
       case 'BLOB':
       case 'GEOMETRY':
+      case 'JSON':
         result = {
           'length_size': parser.parseUnsignedNumber(1)
         };

--- a/lib/code_map.js
+++ b/lib/code_map.js
@@ -1,44 +1,44 @@
 var events = require('./binlog_event');
 var rowsEvents = require('./rows_event');
 
-var EventCode = {
-  UNKNOWN_EVENT: 0x00,
-  START_EVENT_V3: 0x01,
-  QUERY_EVENT: 0x02,
-  STOP_EVENT: 0x03,
-  ROTATE_EVENT: 0x04,
-  INTVAR_EVENT: 0x05,
-  LOAD_EVENT: 0x06,
-  SLAVE_EVENT: 0x07,
-  CREATE_FILE_EVENT: 0x08,
-  APPEND_BLOCK_EVENT: 0x09,
-  EXEC_LOAD_EVENT: 0x0a,
-  DELETE_FILE_EVENT: 0x0b,
-  NEW_LOAD_EVENT: 0x0c,
-  RAND_EVENT: 0x0d,
-  USER_VAR_EVENT: 0x0e,
-  FORMAT_DESCRIPTION_EVENT: 0x0f,
-  XID_EVENT: 0x10,
-  BEGIN_LOAD_QUERY_EVENT: 0x11,
-  EXECUTE_LOAD_QUERY_EVENT: 0x12,
-  TABLE_MAP_EVENT: 0x13,
-  PRE_GA_DELETE_ROWS_EVENT: 0x14,
-  PRE_GA_UPDATE_ROWS_EVENT: 0x15,
-  PRE_GA_WRITE_ROWS_EVENT: 0x16,
-  DELETE_ROWS_EVENT_V1: 0x19,
-  UPDATE_ROWS_EVENT_V1: 0x18,
-  WRITE_ROWS_EVENT_V1: 0x17,
-  INCIDENT_EVENT: 0x1a,
-  HEARTBEAT_LOG_EVENT: 0x1b,
-  IGNORABLE_LOG_EVENT: 0x1c,
-  ROWS_QUERY_LOG_EVENT: 0x1d,
-  WRITE_ROWS_EVENT_V2: 0x1e,
-  UPDATE_ROWS_EVENT_V2: 0x1f,
-  DELETE_ROWS_EVENT_V2: 0x20,
-  GTID_LOG_EVENT: 0x21,
-  ANONYMOUS_GTID_LOG_EVENT: 0x22,
-  PREVIOUS_GTIDS_LOG_EVENT: 0x23
-};
+var CodeEvent = [
+  'UNKNOWN_EVENT',
+  'START_EVENT_V3',
+  'QUERY_EVENT',
+  'STOP_EVENT',
+  'ROTATE_EVENT',
+  'INTVAR_EVENT',
+  'LOAD_EVENT',
+  'SLAVE_EVENT',
+  'CREATE_FILE_EVENT',
+  'APPEND_BLOCK_EVENT',
+  'EXEC_LOAD_EVENT',
+  'DELETE_FILE_EVENT',
+  'NEW_LOAD_EVENT',
+  'RAND_EVENT',
+  'USER_VAR_EVENT',
+  'FORMAT_DESCRIPTION_EVENT',
+  'XID_EVENT',
+  'BEGIN_LOAD_QUERY_EVENT',
+  'EXECUTE_LOAD_QUERY_EVENT',
+  'TABLE_MAP_EVENT',
+  'PRE_GA_DELETE_ROWS_EVENT',
+  'PRE_GA_UPDATE_ROWS_EVENT',
+  'PRE_GA_WRITE_ROWS_EVENT',
+  'WRITE_ROWS_EVENT_V1',
+  'UPDATE_ROWS_EVENT_V1',
+  'DELETE_ROWS_EVENT_V1',
+  'INCIDENT_EVENT',
+  'HEARTBEAT_LOG_EVENT',
+  'IGNORABLE_LOG_EVENT',
+  'ROWS_QUERY_LOG_EVENT',
+  'WRITE_ROWS_EVENT_V2',
+  'UPDATE_ROWS_EVENT_V2',
+  'DELETE_ROWS_EVENT_V2',
+  'GTID_LOG_EVENT',
+  'ANONYMOUS_GTID_LOG_EVENT',
+  'PREVIOUS_GTIDS_LOG_EVENT'
+];
 
 var EventClass = {
   UNKNOWN_EVENT: events.Unknown,
@@ -56,26 +56,6 @@ var EventClass = {
   DELETE_ROWS_EVENT_V2: rowsEvents.DeleteRows,
 };
 
-var getEventName = exports.getEventName = function(code) {
-  var result = 'UNKNOWN_EVENT';
-  Object.keys(EventCode).forEach(function(name) {
-    if (EventCode[name] === code) {
-      result = name;
-      return;
-    }
-  });
-  return result;
-};
-
 exports.getEventClass = function(code) {
-  var eventName = getEventName(code);
-  var result = events.Unknown;
-
-  Object.keys(EventClass).forEach(function(className) {
-    if (eventName === className) {
-      result = EventClass[className];
-      return;
-    }
-  });
-  return result;
+  return EventClass[CodeEvent[code]] || events.Unknown;
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -73,15 +73,11 @@ exports.parseBytesArray = function(parser, length) {
   return result;
 };
 
-var parseSetEnumTypeDef = function(type){
-  var prefixLen;
-  if(type.substr(0,4).toLowerCase() === 'set('){
-    prefixLen = 4;
-  }else if(type.substr(0,5).toLowerCase() === 'enum('){
-    prefixLen = 5;
-  }else{
-    throw 'not set or enum type';
-  }
+// Parse column definition list string for SET and ENUM data types
+// @param type      String  Definition of column 'set(...)' or 'enum(...)'
+// @param prefixLen Integer Number of characters before list starts
+//                          (e.g. 'set(': 4, 'enum(': 5)
+var parseSetEnumTypeDef = function(type, prefixLen){
   // listed distinct elements should not include commas
   return type.substr(prefixLen, type.length - prefixLen - 1)
     .split(',').map(function(opt){
@@ -389,7 +385,8 @@ exports.readMysqlValue = function(parser, column, columnSchema, tableMap, emitte
         low = parser.parseUnsignedNumber(column.metadata.size);
       }
 
-      var choices = parseSetEnumTypeDef(columnSchema.COLUMN_TYPE);
+      // Second argument: prefixLen = 4 'set('
+      var choices = parseSetEnumTypeDef(columnSchema.COLUMN_TYPE, 4);
       result = '';
       for(var i = 0; low >= Math.pow(2, i); i++){
         if(low & Math.pow(2, i)) result += choices[i] + ',';
@@ -403,7 +400,8 @@ exports.readMysqlValue = function(parser, column, columnSchema, tableMap, emitte
       break;
     case MysqlTypes.ENUM:
       var raw = parser.parseUnsignedNumber(column.metadata.size);
-      var choices = parseSetEnumTypeDef(columnSchema.COLUMN_TYPE);
+      // Second argument: prefixLen = 5 'enum('
+      var choices = parseSetEnumTypeDef(columnSchema.COLUMN_TYPE, 5);
       result = choices[raw - 1];
       break;
     case MysqlTypes.VAR_STRING:

--- a/lib/common.js
+++ b/lib/common.js
@@ -355,7 +355,7 @@ var readTemporalFraction = function(parser, fractionPrecision) {
   };
 };
 
-exports.readMysqlValue = function(parser, column, columnSchema) {
+exports.readMysqlValue = function(parser, column, columnSchema, tableMap, emitter) {
   var result;
   // jshint indent: false
   switch (column.type) {
@@ -555,7 +555,12 @@ exports.readMysqlValue = function(parser, column, columnSchema) {
     case MysqlTypes.DECIMAL: // Deprecated in MySQL > 5.0.3
     case MysqlTypes.NEWDATE: // Not used
     default:
-      throw new Error('Unsupported type: ' + column.type);
+      result = undefined;
+      emitter.emit('error',
+        new Error('Unsupported type "' + column.type +
+          '" on column "' + column.name +
+          '" of the table "' + tableMap.tableName +
+          '" in the database "' + tableMap.parentSchema + '"'));
   }
   return result;
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,4 +1,6 @@
-var MysqlTypes = {
+var decodeJson = require('./json_decode');
+
+var MysqlTypes = exports.MysqlTypes = {
   'DECIMAL': 0,
   'TINY': 1,
   'SHORT': 2,
@@ -20,6 +22,8 @@ var MysqlTypes = {
   'TIMESTAMP2': 17,
   'DATETIME2': 18,
   'TIME2': 19,
+  // JSON data type added in MySQL 5.7.7
+  'JSON': 245,
   'NEWDECIMAL': 246,
   'ENUM': 247,
   'SET': 248,
@@ -85,13 +89,13 @@ var parseSetEnumTypeDef = function(type){
     });
 };
 
-var zeroPad = function(num, size) {
+var zeroPad = exports.zeroPad = function(num, size) {
   // Max 32 digits
   var s = "00000000000000000000000000000000" + num;
   return s.substr(s.length-size);
 };
 
-var sliceBits = function(input, start, end){
+var sliceBits = exports.sliceBits = function(input, start, end){
   // ex: start: 10, end: 15 = "111110000000000"
   var match = (((1 << end) - 1) ^ ((1 << start) - 1));
   return (input & match) >> start;
@@ -101,7 +105,7 @@ var sliceBits = function(input, start, end){
 // http://www.h-schmidt.net/FloatConverter/IEEE754.html
 // http://babbage.cs.qc.cuny.edu/IEEE-754.old/64bit.html
 // Pass only high for 32-bit float, pass high and low for 64-bit double
-var parseIEEE754Float = function(high, low){
+var parseIEEE754Float = exports.parseIEEE754Float = function(high, low){
   var lastSignificantBit, sigFigs, expLeading;
   if(low !== undefined){
     // 64-bit: 1 sign, 11 exponent, 52 significand
@@ -138,7 +142,7 @@ var parseIEEE754Float = function(high, low){
   return sign * Math.pow(2, exponent) * significand;
 };
 
-var getUInt32Value = function(input){
+var getUInt32Value = exports.getUInt32Value = function(input){
   // Last bit is not sign, it is part of value!
   if(input & (1 << 31)) return Math.pow(2, 31) + (input & ((1 << 31) -1));
   else return input;
@@ -248,17 +252,22 @@ var parseNewDecimal = function(parser, column) {
     pos += 4;
   }
 
-  str += '.'; // Proceeding bytes are fractional digits
+  // Build fractional digits
+  var fractionDigits = '';
 
   for(var i = 0; i < uncompFractional; i++){
-    str += (buffer.readInt32BE(pos) ^ mask).toString(10);
+    fractionDigits += (buffer.readInt32BE(pos) ^ mask).toString(10);
     pos += 4;
   }
 
   var compFractionalSize = compressedBytes[compFractional];
   if(compFractionalSize > 0){
-    str += (readIntBE(buffer, pos, compFractionalSize) ^ mask).toString(10);
+    fractionDigits +=
+      (readIntBE(buffer, pos, compFractionalSize) ^ mask).toString(10);
   }
+
+  // Fractional digits may have leading zeros
+  str += '.' + zeroPad(fractionDigits, scale);
 
   return parseFloat(str);
 };
@@ -434,6 +443,12 @@ exports.readMysqlValue = function(parser, column, columnSchema) {
       var lengthSize = column.metadata['length_size'];
       result = parser.parseString(
         parser.parseUnsignedNumber(lengthSize));
+      break;
+    case MysqlTypes.JSON:
+      var lengthSize = column.metadata['length_size'];
+      var size = parser.parseUnsignedNumber(lengthSize);
+      var buffer = parser.parseBuffer(size);
+      result = decodeJson(buffer);
       break;
     case MysqlTypes.GEOMETRY:
       var lengthSize = column.metadata['length_size'];

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,39 +2,39 @@ var iconv = require('iconv-lite');
 var decodeJson = require('./json_decode');
 
 var MysqlTypes = exports.MysqlTypes = {
-  'DECIMAL': 0,
-  'TINY': 1,
-  'SHORT': 2,
-  'LONG': 3,
-  'FLOAT': 4,
-  'DOUBLE': 5,
-  'NULL': 6,
-  'TIMESTAMP': 7,
-  'LONGLONG': 8,
-  'INT24': 9,
-  'DATE': 10,
-  'TIME': 11,
-  'DATETIME': 12,
-  'YEAR': 13,
-  'NEWDATE': 14,
-  'VARCHAR': 15,
-  'BIT': 16,
+  DECIMAL: 0,
+  TINY: 1,
+  SHORT: 2,
+  LONG: 3,
+  FLOAT: 4,
+  DOUBLE: 5,
+  NULL: 6,
+  TIMESTAMP: 7,
+  LONGLONG: 8,
+  INT24: 9,
+  DATE: 10,
+  TIME: 11,
+  DATETIME: 12,
+  YEAR: 13,
+  NEWDATE: 14,
+  VARCHAR: 15,
+  BIT: 16,
   // Fractional temporal types in MySQL >=5.6.4
-  'TIMESTAMP2': 17,
-  'DATETIME2': 18,
-  'TIME2': 19,
+  TIMESTAMP2: 17,
+  DATETIME2: 18,
+  TIME2: 19,
   // JSON data type added in MySQL 5.7.7
-  'JSON': 245,
-  'NEWDECIMAL': 246,
-  'ENUM': 247,
-  'SET': 248,
-  'TINY_BLOB': 249,
-  'MEDIUM_BLOB': 250,
-  'LONG_BLOB': 251,
-  'BLOB': 252,
-  'VAR_STRING': 253,
-  'STRING': 254,
-  'GEOMETRY': 255,
+  JSON: 245,
+  NEWDECIMAL: 246,
+  ENUM: 247,
+  SET: 248,
+  TINY_BLOB: 249,
+  MEDIUM_BLOB: 250,
+  LONG_BLOB: 251,
+  BLOB: 252,
+  VAR_STRING: 253,
+  STRING: 254,
+  GEOMETRY: 255,
 };
 
 exports.parseUInt64 = function(parser) {
@@ -331,17 +331,6 @@ var parseGeometryValue = function(buffer){
   return parseGeometry();
 };
 
-var convertToMysqlType = exports.convertToMysqlType = function(code) {
-  var result;
-  Object.keys(MysqlTypes).forEach(function(name) {
-    if (MysqlTypes[name] === code) {
-      result = name;
-      return;
-    }
-  });
-  return result;
-};
-
 var readTemporalFraction = function(parser, fractionPrecision) {
   if(!fractionPrecision) return false;
   var fractionSize = Math.ceil(fractionPrecision / 2);
@@ -566,7 +555,7 @@ exports.readMysqlValue = function(parser, column, columnSchema) {
     case MysqlTypes.DECIMAL: // Deprecated in MySQL > 5.0.3
     case MysqlTypes.NEWDATE: // Not used
     default:
-      throw new Error('Unsupported type: ' + convertToMysqlType(column.type));
+      throw new Error('Unsupported type: ' + column.type);
   }
   return result;
 };

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,3 +1,4 @@
+var iconv = require('iconv-lite');
 var decodeJson = require('./json_decode');
 
 var MysqlTypes = exports.MysqlTypes = {
@@ -441,8 +442,13 @@ exports.readMysqlValue = function(parser, column, columnSchema) {
     case MysqlTypes.LONG_BLOB:
     case MysqlTypes.BLOB:
       var lengthSize = column.metadata['length_size'];
-      result = parser.parseString(
-        parser.parseUnsignedNumber(lengthSize));
+      result = parser.parseBuffer(parser.parseUnsignedNumber(lengthSize));
+
+      // Blobs can be sometimes return as String instead of Buffer
+      // e.g. TINYTEXT, MEDIUMTEXT, LONGTEXT, TEXT data types
+      if(column.charset !== null) {
+        result = iconv.decode(result, column.charset);
+      }
       break;
     case MysqlTypes.JSON:
       var lengthSize = column.metadata['length_size'];

--- a/lib/json_decode.js
+++ b/lib/json_decode.js
@@ -1,0 +1,294 @@
+var common = require('./common');
+var Parser = require('mysql/lib/protocol/Parser');
+
+var JSONB_TYPE_SMALL_OBJECT = 0;
+var JSONB_TYPE_LARGE_OBJECT = 1;
+var JSONB_TYPE_SMALL_ARRAY  = 2;
+var JSONB_TYPE_LARGE_ARRAY  = 3;
+var JSONB_TYPE_LITERAL      = 4;
+var JSONB_TYPE_INT16        = 5;
+var JSONB_TYPE_UINT16       = 6;
+var JSONB_TYPE_INT32        = 7;
+var JSONB_TYPE_UINT32       = 8;
+var JSONB_TYPE_INT64        = 9;
+var JSONB_TYPE_UINT64       = 10;
+var JSONB_TYPE_DOUBLE       = 11;
+var JSONB_TYPE_STRING       = 12;
+var JSONB_TYPE_OPAQUE       = 15;
+
+var JSONB_LITERALS = [ null, true, false ];
+
+// node-mysql prefixes binary string values
+var VAR_STRING_PREFIX = 'base64:type253:';
+
+module.exports = function(input) {
+  // Value must be JSON string to match node-mysql results
+  // Related to this node-mysql PR:
+  // https://github.com/felixge/node-mysql/pull/1299
+  return JSON.stringify(parseBinaryBuffer(input));
+}
+
+/*
+ * @func  parseBinaryBuffer
+ * @param Buffer   input             Full binary JSON representation
+ * @param Integer  offset            Position of the JSONB_TYPE to start
+                                     reading (optional)
+ * @param Integer  parentValueOffset Provided if reading value from nested
+                                     object or array (required if offset
+                                     specified)
+ * @param Function readUInt          Provide alternative function to read
+                                     pointer value for value offset (defaults
+                                     to UInt16LE, large objects/arrays pass
+                                     UInt32LE)
+ * @return Varies
+ */
+function parseBinaryBuffer(input, offset, parentValueOffset, readUInt) {
+  offset = offset || 0;
+  readUInt = readUInt || input.readUInt16LE.bind(input);
+
+  // Only used for types which use the value stored at a pointer position
+  // If object is root (offset 0), the value is not offset by pointer
+  var valueOffset = offset === 0 ? 0 :
+    readUInt(offset + 1) + parentValueOffset;
+
+  var result = null;
+  var jsonType = input.readUInt8(offset);
+  switch(jsonType) {
+    // Small enough types are inlined
+    case JSONB_TYPE_INT16:
+      result = input.readInt16LE(offset + 1);
+      break;
+    case JSONB_TYPE_UINT16:
+      // XXX: No known instance of this type being used
+      result = input.readUInt16LE(offset + 1);
+      break;
+    case JSONB_TYPE_LITERAL:
+      var inlineValue = input.readUInt8(offset + 1);
+      result = JSONB_LITERALS[inlineValue];
+      break;
+    // All other types are retrieved from pointer
+    case JSONB_TYPE_STRING:
+      var strLen, strLenSize = 0, curStrLenByte;
+      // If the high bit is 1, the string length continues to the next byte
+      while(strLenSize === 0 || (curStrLenByte & 128) === 128) {
+        strLenSize++;
+        curStrLenByte = input.readUInt8(valueOffset + strLenSize);
+        if(strLenSize === 1) {
+          strLen = curStrLenByte;
+        } else {
+          strLen = (strLen ^ Math.pow(128, strLenSize - 1))
+            + (curStrLenByte * Math.pow(2, 7 * (strLenSize - 1)));
+        }
+      }
+      result = input.toString('utf8',
+        valueOffset + strLenSize + 1,
+        valueOffset + strLenSize + 1 + strLen);
+      break;
+    case JSONB_TYPE_LARGE_OBJECT:
+      result = readObject(input, valueOffset, true);
+      break;
+    case JSONB_TYPE_SMALL_OBJECT:
+      result = readObject(input, valueOffset, false);
+      break;
+    case JSONB_TYPE_LARGE_ARRAY:
+      result = readArray(input, valueOffset, true);
+      break;
+    case JSONB_TYPE_SMALL_ARRAY:
+      result = readArray(input, valueOffset, false);
+      break;
+    case JSONB_TYPE_DOUBLE:
+      var low = input.readUInt32LE(valueOffset + 1);
+      var high = input.readUInt32LE(valueOffset + 5);
+      result = common.parseIEEE754Float(high, low);
+      break;
+    case JSONB_TYPE_INT32:
+      result = input.readInt32LE(valueOffset + 1);
+      break;
+    case JSONB_TYPE_UINT32:
+      // XXX: No known instance of this type being used
+      result = input.readUInt32LE(valueOffset + 1);
+      break;
+    case JSONB_TYPE_INT64:
+      var low = input.readUInt32LE(valueOffset + 1);
+      var high = input.readUInt32LE(valueOffset + 5);
+      if(high & (1 << 31)) {
+        // Javascript integers only support 2^53 not 2^64, must trim bits!
+        // 64-53 = 11, 32-11 = 21, so grab first 21 bits of high word only
+        var mask = Math.pow(2, 32) - 1;
+        high = common.sliceBits(high ^ mask, 0, 21);
+        low = low ^ mask;
+        result =
+          ((high * Math.pow(2, 32)) * - 1) - common.getUInt32Value(low) - 1;
+      } else {
+        result = (high * Math.pow(2,32)) + low;
+      }
+      break;
+    case JSONB_TYPE_UINT64:
+      var low = input.readUInt32LE(valueOffset + 1);
+      var high = input.readUInt32LE(valueOffset + 5);
+      result = (high * Math.pow(2,32)) + low;
+      break;
+    case JSONB_TYPE_OPAQUE:
+      var customType = input.readUInt8(valueOffset + 1);
+      var dataLen, dataLenSize = 0, curDataLenByte;
+      // If the high bit is 1, the string length continues to the next byte
+      while(dataLenSize === 0 || (curDataLenByte & 128) === 128) {
+        dataLenSize++;
+        curDataLenByte = input.readUInt8(valueOffset + 1 + dataLenSize);
+        if(dataLenSize === 1) {
+          dataLen = curDataLenByte;
+        } else {
+          dataLen = (dataLen ^ Math.pow(128, dataLenSize - 1))
+            + (curDataLenByte * Math.pow(2, 7 * (dataLenSize - 1)));
+        }
+      }
+
+      // Configure parser and metadata if using standard readMysqlValue
+      // from common.js, otherwise set result for custom decoding
+      var parser = new Parser();
+      var metadata = {};
+      var parseType = customType;
+
+      parser.append(input.slice(
+        valueOffset + dataLenSize + 2,
+        valueOffset + dataLenSize + 2 + dataLen));
+
+      switch(customType) {
+        case common.MysqlTypes.DATE:
+          var raw = parser._buffer.readInt32LE(4);
+          var yearMonth = common.sliceBits(raw, 14, 31);
+          result =
+            common.zeroPad(Math.floor(yearMonth / 13), 4) + '-' +  // year
+            common.zeroPad(yearMonth % 13, 2) + '-' +              // month
+            common.zeroPad(common.sliceBits(raw, 9, 14), 2)        // day
+          break;
+        case common.MysqlTypes.TIME:
+          var raw = parser._buffer.readUInt32LE(3);
+          var fraction = common.sliceBits(parser._buffer.readInt32LE(0), 0, 24);
+
+          var isNegative = (raw & (1 << 23)) !== 0;
+          if(isNegative) {
+            raw = (raw ^ ((1 << 24) - 1)) + 1; // flip all bits
+            // If fraction exists, last bit adjustment goes to microseconds
+            if(fraction) {
+              fraction = (fraction ^ ((1 << 24) - 1)) + 1;
+              raw--;
+            }
+          }
+
+          var hour = common.sliceBits(raw, 12, 22);
+          var minute = common.sliceBits(raw, 6, 12);
+          var second = common.sliceBits(raw, 0, 6);
+
+          result = (isNegative ? '-' : '') +
+                   common.zeroPad(hour, hour > 99 ? 3 : 2) + ':' +
+                   common.zeroPad(minute, 2) + ':' +
+                   common.zeroPad(second, 2) +
+                   '.' + common.zeroPad(fraction, 6);
+          break;
+        case common.MysqlTypes.DATETIME:
+          // Overlapping high-low to get all data in 32-bit numbers
+          var rawHigh = parser._buffer.readUInt32LE(3);
+          var rawLow = parser._buffer.readUInt32LE(4);
+          var fraction = common.sliceBits(parser._buffer.readInt32LE(0), 0, 24);
+
+          var yearMonth = common.sliceBits(rawLow, 14, 31);
+          result =
+            common.zeroPad(Math.floor(yearMonth / 13), 4) + '-' +        // year
+            common.zeroPad(yearMonth % 13, 2) + '-' +                    // month
+            common.zeroPad(common.sliceBits(rawLow, 9, 14), 2) + ' ' +   // day
+            common.zeroPad(common.sliceBits(rawHigh, 12, 17), 2) + ':' + // hour
+            common.zeroPad(common.sliceBits(rawHigh, 6, 12), 2) + ':' +  // minutes
+            common.zeroPad(common.sliceBits(rawHigh, 0, 6), 2) + '.' +   // seconds
+            common.zeroPad(fraction, 6);
+          break;
+        case common.MysqlTypes.NEWDECIMAL:
+          metadata = {
+            precision: parser.parseUnsignedNumber(1),
+            decimals: parser.parseUnsignedNumber(1),
+          };
+          break;
+        case common.MysqlTypes.VAR_STRING:
+          result = VAR_STRING_PREFIX + parser._buffer.toString('base64');
+          break;
+        default:
+          throw new Error('JSON Opaque Type Not Implemented: ' + customType);
+      }
+
+      // If a result has not already been returned, try using the
+      // value reader for normal binary values (not JSON)
+      if(result === null) {
+        result = common.readMysqlValue(parser, {
+          type: parseType,
+          metadata: metadata
+        });
+      }
+      break;
+    default:
+      throw new Error('JSON Type Not Implemented: ' + jsonType);
+  }
+  return result;
+}
+
+function readObject(input, valueOffset, isLarge) {
+  if(isLarge) {
+    var readUInt = input.readUInt32LE.bind(input);
+    var intSize = 4;
+  } else {
+    var readUInt = input.readUInt16LE.bind(input);
+    var intSize = 2;
+  }
+
+  var result = {};
+  var memberCount = readUInt(valueOffset + 1); // +1 = JSON type byte
+  var binarySize = readUInt(valueOffset + 1 + intSize);
+
+  // Position where key entries start
+  // Key entry: Key offset (int16/32) + Key length (int16)
+  var memberKeyStart =
+    valueOffset + 1 + // Beginning of definition
+    (intSize * 2);   // memberCount + binarySize
+
+  // Value entries (or pointers to such) begin after key entries
+  var memberValueStart = memberKeyStart + (memberCount * (intSize + 2));
+
+  for(var pointerPos = 0; pointerPos < memberCount; pointerPos++) {
+    var keyEntryPos = memberKeyStart + (pointerPos * (intSize + 2));
+
+    var keyStart = valueOffset + 1 + readUInt(keyEntryPos);
+    var keyEnd = keyStart + input.readUInt16LE(keyEntryPos + intSize);
+
+    var thisKey = input.toString('utf8', keyStart, keyEnd);
+    var memberValueOffset = memberValueStart + (pointerPos * (intSize + 1));
+
+    result[thisKey] =
+      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt);
+  }
+
+  return result;
+}
+
+function readArray(input, valueOffset, isLarge) {
+  if(isLarge) {
+    var readUInt = input.readUInt32LE.bind(input);
+    var intSize = 4;
+  } else {
+    var readUInt = input.readUInt16LE.bind(input);
+    var intSize = 2;
+  }
+
+  var result = [];
+  var memberCount = readUInt(valueOffset + 1); // +1 = JSON type byte
+  var binarySize = readUInt(valueOffset + 1 + intSize);
+
+  for(var pointerPos = 0; pointerPos < memberCount; pointerPos++) {
+    var memberValueOffset =
+      valueOffset + 1 + // Beginning of definition
+      (intSize * 2) +   // memberCount + binarySize
+      (pointerPos * (1 + intSize)); // value type + value offset
+
+    result.push(
+      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt));
+  }
+  return result;
+}

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -5,11 +5,6 @@ var UNSIGNED_SHORT_COLUMN = 252;
 var UNSIGNED_INT24_COLUMN = 253;
 var UNSIGNED_INT64_COLUMN = 254;
 
-var UNSIGNED_CHAR_LENGTH = 1;
-var UNSIGNED_SHORT_LENGTH = 2;
-var UNSIGNED_INT24_LENGTH = 3;
-var UNSIGNED_INT64_LENGTH = 8;
-
 function BufferReader(buffer) {
   this.buffer = buffer;
   this.position = 0;

--- a/lib/rows_event.js
+++ b/lib/rows_event.js
@@ -20,6 +20,7 @@ var CHECKSUM_SIZE = 4;
 
 function RowsEvent(parser, options, zongji) {
   BinlogEvent.apply(this, arguments);
+  this._zongji = zongji;
   this._readTableId(parser);
   this.flags = parser.parseUnsignedNumber(2);
   this.useChecksum = zongji.useChecksum;
@@ -91,10 +92,10 @@ RowsEvent.prototype.dump = function() {
 };
 
 RowsEvent.prototype._fetchOneRow = function(parser) {
-  return readRow(this.tableMap[this.tableId], parser);
+  return readRow(this.tableMap[this.tableId], parser, this._zongji);
 };
 
-var readRow = function(tableMap, parser) {
+var readRow = function(tableMap, parser, emitter) {
   var row = {}, column, columnSchema;
   var nullBitmapSize = Math.floor((tableMap.columns.length + 7) / 8);
   var nullBuffer = parser._buffer.slice(parser._offset, 
@@ -108,7 +109,8 @@ var readRow = function(tableMap, parser) {
     column = tableMap.columns[i];
     columnSchema = tableMap.columnSchemas[i];
     if((curNullByte & (1 << curBit)) === 0){
-      row[column.name] = Common.readMysqlValue(parser, column, columnSchema);
+      row[column.name] =
+        Common.readMysqlValue(parser, column, columnSchema, tableMap, emitter);
     }else{
       row[column.name] = null;
     }
@@ -139,8 +141,8 @@ util.inherits(UpdateRows, RowsEvent);
 UpdateRows.prototype._fetchOneRow = function(parser) {
   var tableMap = this.tableMap[this.tableId];
   return {
-    before: readRow(tableMap, parser),
-    after: readRow(tableMap, parser)
+    before: readRow(tableMap, parser, this._zongji),
+    after: readRow(tableMap, parser, this._zongji)
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "zongji",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "A mysql binlog listener running on Node.js",
   "main": "index.js",
-  "engines": {
-    "node": "0.10"
-  },
   "directories": {
     "test": "test"
   },
@@ -30,10 +27,10 @@
   },
   "homepage": "https://github.com/nevill/zongji",
   "devDependencies": {
-    "nodeunit": "~0.9.0"
+    "nodeunit": "~0.9.1"
   },
   "dependencies": {
     "iconv-lite": "^0.4.13",
-    "mysql": "~2.5.5"
+    "mysql": "~2.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "nodeunit": "~0.9.0"
   },
   "dependencies": {
+    "iconv-lite": "^0.4.13",
     "mysql": "~2.5.5"
   }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,5 +1,5 @@
 var ZongJi = require('./../');
-
+var getEventClass = require('./../lib/code_map').getEventClass;
 
 module.exports = {
   invalid_host: function(test) {
@@ -12,5 +12,10 @@ module.exports = {
       test.equal(error.code, 'ENOTFOUND');
       test.done();
     });
+  },
+  code_map: function(test) {
+    test.equal(getEventClass(2).name, 'Query');
+    test.equal(getEventClass(490).name, 'Unknown');
+    test.done();
   }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,16 @@
+var ZongJi = require('./../');
+
+
+module.exports = {
+  invalid_host: function(test) {
+    var zongji = new ZongJi({
+      host: 'wronghost',
+      user: "wronguser",
+      password: "wrongpass"
+    });
+    zongji.on('error', function(error) {
+      test.equal(error.code, 'ENOTFOUND');
+      test.done();
+    });
+  }
+}

--- a/test/events.js
+++ b/test/events.js
@@ -81,7 +81,7 @@ module.exports = {
           expectEvents(test, events, [
             { /* do not bother testing anything on first event */ },
             { rows: [ { col: 10 } ] }
-          ], function(){
+          ], 1, function(){
             zongji.stop();
             test.done();
           });
@@ -118,7 +118,7 @@ module.exports = {
           _checkTableMap: checkTableMatches(testTable),
           rows: [ { col: 15 } ]
         }
-      ], function(){
+      ], 1, function(){
         test.equal(conn.errorLog.length, 0);
         test.done();
       });
@@ -175,7 +175,7 @@ module.exports = {
       expectEvents(test, conn.eventLog, [
         { /* do not bother testing anything on first event */ },
         { rows: results[results.length - 1] }
-      ], test.done);
+      ], 1, test.done);
     });
   },
 };

--- a/test/helpers/expectEvents.js
+++ b/test/helpers/expectEvents.js
@@ -8,18 +8,19 @@ var MAX_WAIT = 3000;
 // @param {function} expected.$._[custom] - Apply custom tests for this event
 //                                          function(test, event){}
 // @param {any} expected.$.[key] - Deep match any other values
+// @param {number} multiplier - Number of times to expect expected events
 // @param {function} callback - Call when done, no arguments (optional)
 // @param waitIndex - Do not specify, used internally
-var expectEvents = module.exports = function(test, events, expected, callback, waitIndex){
-  if(events.length < expected.length && !(waitIndex > 10)){
+function expectEvents(test, events, expected, multiplier, callback, waitIndex){
+  if(events.length < (expected.length * multiplier) && !(waitIndex > 10)){
     // Wait for events to appear
     setTimeout(function(){
-      expectEvents(test, events, expected, callback, (waitIndex || 0) + 1);
+      expectEvents(test, events, expected, multiplier, callback, (waitIndex || 0) + 1);
     }, MAX_WAIT / 10);
   }else{
-    test.strictEqual(events.length, expected.length);
+    test.strictEqual(events.length, expected.length * multiplier);
     events.forEach(function(event, index){
-      var exp = expected[index];
+      var exp = expected[index % expected.length];
       for(var i in exp){
         if(exp.hasOwnProperty(i)){
           if(i === '_type'){
@@ -35,3 +36,5 @@ var expectEvents = module.exports = function(test, events, expected, callback, w
     if(typeof callback === 'function') callback();
   }
 };
+
+module.exports = expectEvents;

--- a/test/helpers/strRepeat.js
+++ b/test/helpers/strRepeat.js
@@ -1,0 +1,10 @@
+module.exports = function (pattern, count) {
+  if (count < 1) return '';
+  var result = '';
+  var pos = 0;
+  while (pos < count) {
+    result += pattern.replace(/##/g, pos);
+    pos++;
+  }
+  return result;
+} 

--- a/test/types.js
+++ b/test/types.js
@@ -233,18 +233,7 @@ defineTypeTest('blob', [
   ['"something here"', '"tiny"', '"medium"', '"long"'],
   ['"nothing there"', '"small"', '"average"', '"huge"'],
   [null, null, null, null]
-], function(test, event) {
-  // XXX: Blobs return as String from binlog instead of Buffer
-  event.rows.forEach(function(row, index) {
-    var expected = this[index];
-    for(var field in expected) {
-      if(expected.hasOwnProperty(field) && expected[field] instanceof Buffer) {
-        expected[field] = expected[field].toString();
-      }
-    }
-    test.deepEqual(expected, row);
-  }.bind(this));
-});
+]);
 
 defineTypeTest('geometry', [
   'GEOMETRY',
@@ -340,10 +329,10 @@ defineTypeTest('string', [
 defineTypeTest('text', [
   'TINYTEXT NULL',
   'MEDIUMTEXT NULL',
-  'LONGTEXT NULL',
+  'LONGTEXT CHARACTER SET utf8 NULL',
   'TEXT NULL'
 ], [
-  ['"something here"', '"tiny"', '"a"', '"binary"'],
+  ['"something here"', '"tiny"', '"á"', '"binary"'],
   ['"nothing there"', '"small"', '"b"', '"test123"'],
   [null, null, null, null]
 ]);

--- a/test/types.js
+++ b/test/types.js
@@ -2,6 +2,7 @@ var settings = require('./settings/mysql');
 var connector =  require('./helpers/connector');
 var querySequence = require('./helpers/querySequence');
 var expectEvents = require('./helpers/expectEvents');
+var strRepeat = require('./helpers/strRepeat');
 
 var conn = process.testZongJi || {};
 
@@ -44,22 +45,24 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion){
     var insertColumns = fields.map(function(field, index){
       return 'col' + index;
     }).join(', ');
-    var insertRows = testRows.map(function(row){
-      return '(' + row.map(function(field){
-        return field === null ? 'null' : field;
-      }).join(', ') + ')';
-    }).join(', ');
-
-    if(!minVersion || checkVersion(minVersion, conn.mysqlVersion)){
-      querySequence(conn.db, [
+    var testQueries = [
         'DROP TABLE IF EXISTS ' + conn.escId(testTable),
         'CREATE TABLE ' + conn.escId(testTable) + ' (' + fieldText + ')',
-        'SET @@session.time_zone = "+00:00"',
-        'INSERT INTO ' + conn.escId(testTable) +
-          ' (' + insertColumns + ') VALUES ' + insertRows,
+        'SET @@session.time_zone = "+00:00"']
+      .concat(testRows.map(function(row){
+        return 'INSERT INTO ' + conn.escId(testTable) +
+          ' (' + insertColumns + ') VALUES (' +
+            row.map(function(field){
+              return field === null ? 'null' : field;
+            }).join(', ') + ')';
+      }))
+      .concat([
         'SET @@session.time_zone = "SYSTEM"',
         'SELECT * FROM ' + conn.escId(testTable)
-      ], function(results){
+      ]);
+
+    if(!minVersion || checkVersion(minVersion, conn.mysqlVersion)){
+      querySequence(conn.db, testQueries, function(results){
         var selectResult = results[results.length - 1];
         var expectedWrite = {
           _type: 'WriteRows',
@@ -70,22 +73,6 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion){
           }
         };
 
-        if(customTest){
-          expectedWrite._custom = customTest.bind(selectResult);
-        }else{
-          expectedWrite.rows = selectResult.map(function(row){
-            for(var field in row){
-              if(row.hasOwnProperty(field) &&
-                  row[field] instanceof Buffer &&
-                  name === 'blob'){
-                // Special case where blobs return as String instead of Buffer
-                row[field] = row[field].toString();
-              }
-            }
-            return row;
-          });
-        };
-
         expectEvents(test, conn.eventLog, [
           {
             _type: 'TableMap',
@@ -93,12 +80,24 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion){
             schemaName: settings.database
           },
           expectedWrite
-        ], function(){
+        ], testRows.length, function(){
           test.equal(conn.errorLog.length, 0);
           conn.errorLog.length &&
             console.log('Type Test Error: ', name, conn.errorLog);
           if(conn.errorLog.length){
             throw conn.errorLog[0];
+          }
+          var binlogRows = conn.eventLog.reduce(function(prev, curr, index) {
+            if(curr.getTypeName() === 'WriteRows') {
+              prev = prev.concat(curr.rows);
+            }
+            return prev;
+          }, []);
+
+          if(customTest) {
+            customTest.bind(selectResult)(test, { rows: binlogRows });
+          } else {
+            test.deepEqual(selectResult, binlogRows);
           }
 
           test.done();
@@ -221,7 +220,8 @@ defineTypeTest('decimal', [
   'DECIMAL(30, 10) NULL'
 ], [
   [1.0], [-1.0], [123.456], [-13.47],
-  [123456789.123], [-123456789.123], [null]
+  [123456789.123], [-123456789.123], [null],
+  [1447410019.012], [123.00000123]
 ]);
 
 defineTypeTest('blob', [
@@ -233,7 +233,18 @@ defineTypeTest('blob', [
   ['"something here"', '"tiny"', '"medium"', '"long"'],
   ['"nothing there"', '"small"', '"average"', '"huge"'],
   [null, null, null, null]
-]);
+], function(test, event) {
+  // XXX: Blobs return as String from binlog instead of Buffer
+  event.rows.forEach(function(row, index) {
+    var expected = this[index];
+    for(var field in expected) {
+      if(expected.hasOwnProperty(field) && expected[field] instanceof Buffer) {
+        expected[field] = expected[field].toString();
+      }
+    }
+    test.deepEqual(expected, row);
+  }.bind(this));
+});
 
 defineTypeTest('geometry', [
   'GEOMETRY',
@@ -345,3 +356,148 @@ defineTypeTest('datetime_then_decimal', [
   ['"9999-12-31 23:59:59.001"', -123.45],
   ['"2014-12-27 01:07:08.053"', 12345.123]
 ], '5.6.4');
+
+defineTypeTest('json', [
+  'JSON NULL'
+], [
+  // Small Object
+  ['\'{"key1": "value1", "key2": "value2", "key3": 34}\''],
+  // Small Object with nested object
+  ['\'{"key1": { "key2": "value2", "key3": 34 } }\''],
+  // Small Object with double nested object
+  ['\'{"key1": { "key2": { "key2": "value2", "key3": 34 }, "key3": 34 } }\''],
+  // Small Object with unicode character in key and value
+  ['\'{ "key2": "válue2", "keybá3": 34 }\''],
+  // Large Object
+  ['\'{' + strRepeat('"key##": "value##", ', 2839) + '"keyLast": 34}\''],
+  // Large Object with nested small objects
+  ['\'{' + strRepeat('"key##": {"subkey": "value##"}, ', 2000) + '"keyLast": 34}\''],
+  // Large Object with nested small arrays
+  ['\'{' + strRepeat('"key##": ["a", ##], ', 3000) + '"keyLast": 34}\''],
+  // Small array
+  ['\'["a", "b", 1]\''],
+  // Small array with nested array
+  ['\'["a", [2, "b"], 1]\''],
+  // Small array with double nested array
+  ['\'["a", [2, ["b", 4, 54]], 1]\''],
+  // Large Array
+  ['\'[' + strRepeat('"value##", ', 6000) + '34]\''],
+  // Large Array with nested small objects
+  ['\'[' + strRepeat('{"key##": "value##"}, ', 6000) + '34]\''],
+  // Large Array with nested small arrays
+  ['\'[' + strRepeat('[##, "value##"], ', 6000) + '34]\''],
+  // Strings of various lengths
+  ['\'"hello"\''],
+  ['\'{"twobytelen": "' + strRepeat('a', 256) + '"}\''],
+  ['\'{"twobytelen": "' + strRepeat('a', 257) + '"}\''],
+  ['\'{"twobytelen": "' + strRepeat('a', 258) + '"}\''],
+  ['\'{"twobytelen": "' + strRepeat('a', 7383) + '"}\''],
+  ['\'{"twobytelen": "' + strRepeat('a', 16383) + '"}\''],
+  ['\'{"threebytelen": "' + strRepeat('a', 16388) + '"}\''],
+  // Integers
+  ['\'{"key1": -10, "keyb": 34}\''],
+  ['\'10\''],
+  ['\'2147483647\''], // Int32
+  ['\'-2147483647\''], // Int32
+  ['\'2147483648\''], // Int64
+  ['\'4294967295\''], // Int64
+  ['\'-4294967295\''], // Int64
+  ['\'9007199254740992\''], // UInt64
+  ['\'-9007199254740992\''], // Int64
+  ['\'3e2\''],
+  ['\'-3e-2\''],
+  // Doubles
+  ['\'10.123\''],
+  ['\'{"doubleval": "-123.38439", "another": 1283192.0004}\''],
+  // Literals
+  ['\'{"literaltest1": null, "literal2": true, "literal3": false}\''],
+  ['\'{"literaltest1": null, "stringafter": "heyos", "number": 35}\''],
+  ['\'null\''],
+  ['\'true\''],
+  ['\'false\''],
+  // Opaque custom data
+  ['JSON_OBJECT(\'key\', BINARY \'hi\')'],
+  ['JSON_OBJECT(\'key\', MAKEDATE(2014,361))'],
+  ['JSON_OBJECT(\'key\', DATE(\'100-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'1000-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'1000-01-02\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'1000-01-03\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'1000-02-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'1000-12-31\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2001-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2002-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2003-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2004-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'9999-01-01\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'9999-12-31\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2002-02-02\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2002-03-03\'))'],
+  ['JSON_OBJECT(\'key\', DATE(\'2002-12-12\'))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(-838,59,59))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(838,59,59))'],
+  ['JSON_OBJECT(\'zero\', MAKETIME(0,0,0))'],
+  ['JSON_OBJECT(\'onehour\', MAKETIME(1,0,0))'],
+  ['JSON_OBJECT(\'oneminu\', MAKETIME(0,1,0))'],
+  ['JSON_OBJECT(\'oneseco\', MAKETIME(0,0,1))'],
+  ['JSON_OBJECT(\'hurnsec\', MAKETIME(1,0,1))'],
+  ['JSON_OBJECT(\'minnsec\', MAKETIME(0,1,1))'],
+  ['JSON_OBJECT(\'2minsec\', MAKETIME(0,2,2))'],
+  ['JSON_OBJECT(\'2min15sec\', MAKETIME(0,2,15))'],
+  ['JSON_OBJECT(\'2min16sec\', MAKETIME(0,2,16))'],
+  ['JSON_OBJECT(\'2min32sec\', MAKETIME(0,2,32))'],
+  ['JSON_OBJECT(\'2min59sec\', MAKETIME(0,2,59))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(0,59,0))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(0,0,59))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(20,15,10))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(21,15,10))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(22,15,10))'],
+  ['JSON_OBJECT(\'oneseco\', MAKETIME(0,0,1.123))'],
+  ['JSON_OBJECT(\'oneseco\', MAKETIME(0,0,1.000123))'],
+  ['JSON_OBJECT(\'key\', MAKETIME(-20,00,00))'],
+  ['JSON_OBJECT(\'-59min\', TIME(\'-00:00:00.003\'))'],
+  ['JSON_OBJECT(\'-59min\', TIME(\'00:00:00.003\'))'],
+  ['JSON_OBJECT(\'-59min\', TIME(\'-00:59:59\'))'],
+  ['JSON_OBJECT(\'-59min\', TIME(\'-00:59:59.0003\'))'],
+  ['JSON_OBJECT(\'-1hr\', MAKETIME(-1,00,00))'],
+  ['JSON_OBJECT(\'-2hr\', MAKETIME(-2,00,00))'],
+  ['JSON_OBJECT(\'-1hr1sec\', MAKETIME(-1,00,1))'],
+  ['JSON_OBJECT(\'-1hr1sec\', MAKETIME(-1,00,0.1))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-27\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-27 01:07:08\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-27 01:07:08.123\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-27 01:07:08.000456\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-28\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2014-12-29\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2003-12-31 12:00:00\'))'],
+  ['JSON_OBJECT(\'key\', TIMESTAMP(\'2003-12-31 12:00:00.123\'))'],
+  ['JSON_OBJECT(\'key\', UNIX_TIMESTAMP(\'2015-11-13 10:20:19.012\'))'],
+], function(test, event){
+  // JSON from MySQL client has different whitespace than JSON.stringify
+  // Therefore, parse and perform deep equality
+  event.rows.forEach(function(row, index) {
+    // test.deepEqual does not work when comparison objects exceed 65536 bytes
+    // Perform alternative assertions for these large cases
+    var expected = JSON.parse(this[index].col0);
+    var actual = JSON.parse(row.col0);
+    if(this[index].col0.length > 65536) {
+      // Large cases are either array or object
+      if(expected instanceof Array) {
+        test.strictEqual(expected.length, actual.length);
+        for(var i = 0; i < expected.length; i++) {
+          test.deepEqual(expected[i], actual[i]);
+        }
+      } else {
+        var expectedKeys = Object.keys(expected);
+        var actualKeys = Object.keys(actual);
+        test.strictEqual(expectedKeys.length, actualKeys.length);
+        test.deepEqual(expectedKeys, actualKeys);
+        for(var i = 0; i < expectedKeys.length; i++) {
+          test.deepEqual(expected[expectedKeys[i]], actual[expectedKeys[i]]);
+        }
+      }
+    } else {
+      // Comparison objects are smaller than 65536 bytes
+      test.deepEqual(expected, actual);
+    }
+  }.bind(this));
+}, '5.7.8');


### PR DESCRIPTION
Here is my proposal for the next release version of ZongJi.

Main new feature is JSON data type support! https://github.com/nevill/zongji/commit/334291684e1d1ffbd86e1a1e206c8acf96f72dd2 ([More details](https://github.com/nevill/zongji/pull/25)) I think I've come up with every necessary test case for the crazy `OPAQUE` data type. :+1: 

I have bumped the version to 0.4.0 instead of 0.3.3 because of the breaking change regarding how blob types are now returned. https://github.com/nevill/zongji/commit/509cb6e2762b2c01e16be16013441f73eee35470 Previously, `BLOB`/`TEXT` types would always output String values. This behavior matches `node-mysql` for `TEXT` types but `BLOB` values return Buffer. With this commit, the ZongJi behavior now matches `node-mysql`. Anybody depending on `BLOB` values to return String will from ZongJi will need to update their code to accept Buffer.

There is also [a bugfix for the `DECIMAL` data type](https://github.com/nevill/zongji/commit/334291684e1d1ffbd86e1a1e206c8acf96f72dd2#diff-1ffb5a9090758229a335b02a477425c7R270). Previously, values with leading zeros in the fractional decimal would have its leading zeros dropped. (e.g. `123.000123` became `123.123`) This has now been fixed.

I have also included some commits from @jmealo's [PR](https://github.com/nevill/zongji/pull/33).

It would be nice to have automated tests for these commits https://github.com/nevill/zongji/commit/58fd776033917b1d1a81fd620071a56ce84b9dce, https://github.com/nevill/zongji/commit/aab7134ff4f3bbfe4d78312316317b802a25cf9b, https://github.com/nevill/zongji/commit/30ce5c2d8c36d2c865eee87c1cf5b64bf5c2910a but I can't think of a way to do it without a test runner that creates MySQL accounts for each case to check permission failures.

Any comments? Am I missing anything?