### PR TITLE
Fixed the recursive emitError bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,15 +12,15 @@ function ZongJi(dsn, options) {
   var ctrlDsn = cloneObjectSimple(dsn);
   ctrlDsn.database = 'information_schema';
   this.ctrlConnection = mysql.createConnection(ctrlDsn);
-  this.ctrlConnection.on('error', this._emitError);
-  this.ctrlConnection.on('unhandledError', this._emitError);
+  this.ctrlConnection.on('error', this._emitError.bind(this));
+  this.ctrlConnection.on('unhandledError', this._emitError.bind(this));
 
   this.ctrlConnection.connect();
   this.ctrlCallbacks = [];
 
   this.connection = mysql.createConnection(dsn);
-  this.connection.on('error', this._emitError);
-  this.connection.on('unhandledError', this._emitError);
+  this.connection.on('error', this._emitError.bind(this));
+  this.connection.on('unhandledError', this._emitError.bind(this));
 
   this.tableMap = {};
   this.ready = false;


### PR DESCRIPTION
Within `ZongJi.prototype._emitError` function `this` refers to `Connection` object of mysql library and thereby leads to the infinite recursion.

## How to reproduce bug?

1. Open `example.js` and temporarily commented out `evt.dump();`
2. Open the terminal and run
```
user$ node example.js
```
3. Open second terminal window and print
```
user$ mysql -u root
mysql> SHOW PROCESSLIST;
+------+------+-----------------+--------------------+-------------+------+-----------------------------------------------------------------------+------------------+
| Id   | User | Host            | db                 | Command     | Time | State                                                                 | Info             |
+------+------+-----------------+--------------------+-------------+------+-----------------------------------------------------------------------+------------------+
| 2126 | root | localhost:35423 | information_schema | Sleep       |  107 |                                                                       | NULL             |
| 2127 | root | localhost:35424 | NULL               | Binlog Dump |  112 | Master has sent all binlog to slave; waiting for binlog to be updated | NULL             |
| 2151 | root | localhost       | NULL               | Query       |    0 | init                                                                  | SHOW PROCESSLIST |
+------+------+-----------------+--------------------+-------------+------+-----------------------------------------------------------------------+------------------+
mysql> KILL 2127; //specify your connection id.
```
Now come back to first terminal window and you will see:
```
events.js:75                                                                    
function emitOne(handler, isFn, self, arg1) {                                   
                ^                                                               
                                                                                
RangeError: Maximum call stack size exceeded                                    
    at emitOne (events.js:75:17)                                                
    at Connection.emit (events.js:169:7)                                        
    at Connection.ZongJi._emitError (/home/sda/www/zongji/index.js:273:8)       
    at emitOne (events.js:77:13)                                                
    at Connection.emit (events.js:169:7)                                        
    at Connection.ZongJi._emitError (/home/sda/www/zongji/index.js:273:8)       
    at emitOne (events.js:77:13)                                                
    at Connection.emit (events.js:169:7)                                        
    at Connection.ZongJi._emitError (/home/sda/www/zongji/index.js:273:8)
    at emitOne (events.js:77:13)
```

This pull request fixes the bug by pointing `this` to `ZongJi` object.