### PR TITLE
Testing utf8mb4 charset support

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -434,6 +434,8 @@ exports.readMysqlValue = function(parser, column, columnSchema, tableMap, emitte
       // Blobs can be sometimes return as String instead of Buffer
       // e.g. TINYTEXT, MEDIUMTEXT, LONGTEXT, TEXT data types
       if(column.charset !== null) {
+        // Javascript UTF8 always allows up to 4 bytes per character
+        column.charset = column.charset === 'utf8mb4' ? 'utf8' : column.charset;
         result = iconv.decode(result, column.charset);
       }
       break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zongji",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A mysql binlog listener running on Node.js",
   "main": "index.js",
   "directories": {

--- a/test/events.js
+++ b/test/events.js
@@ -57,7 +57,8 @@ module.exports = {
       'DROP TABLE IF EXISTS ' + conn.escId(testTable),
       'CREATE TABLE ' + conn.escId(testTable) + ' (col INT UNSIGNED)',
       'INSERT INTO ' + conn.escId(testTable) + ' (col) VALUES (10)',
-    ], function(results){
+    ], function(error, results){
+      if(error) console.error(error);
       // Start second ZongJi instance
       var zongji = new ZongJi(settings.connection);
       var events = [];
@@ -76,7 +77,8 @@ module.exports = {
       setTimeout(function(){
         querySequence(conn.db, [
           'INSERT INTO ' + conn.escId(testTable) + ' (col) VALUES (10)',
-        ], function(results){
+        ], function(error, results){
+          if(error) console.error(error);
           // Should only have 2 events since ZongJi start
           expectEvents(test, events, [
             { /* do not bother testing anything on first event */ },
@@ -98,7 +100,8 @@ module.exports = {
       'INSERT INTO ' + conn.escId(testTable) + ' (col) VALUES (10)',
       'UPDATE ' + conn.escId(testTable) + ' SET col = 15',
       'DELETE FROM ' + conn.escId(testTable)
-    ], function(){
+    ], function(error, results){
+      if(error) console.error(error);
       expectEvents(test, conn.eventLog, [
         tableMapEvent(testTable),
         {
@@ -171,7 +174,8 @@ module.exports = {
           '(123456, 100, 96, 300, 1000, null), ' +
           '(-123456, -100, -96, -300, -1000, null)',
        'SELECT * FROM ' + conn.escId(testTable)
-    ], function(results){
+    ], function(error, results){
+      if(error) console.error(error);
       expectEvents(test, conn.eventLog, [
         { /* do not bother testing anything on first event */ },
         { rows: results[results.length - 1] }

--- a/test/filtering.js
+++ b/test/filtering.js
@@ -92,7 +92,8 @@ module.exports = {
       'INSERT INTO ' + conn.escId(testTable) + ' (col) VALUES (10)',
       'UPDATE ' + conn.escId(testTable) + ' SET col = 15',
       'DELETE FROM ' + conn.escId(testTable)
-    ], function(){
+    ], function(error, result){
+      if(error) console.error(error);
       // Give 1 second to see if any events are emitted, they should not be!
       setTimeout(function(){
         conn.zongji.set(origOptions);

--- a/test/helpers/connector.js
+++ b/test/helpers/connector.js
@@ -20,7 +20,8 @@ module.exports = function(settings, callback){
     'USE ' + escId(settings.database),
     'RESET MASTER',
     'SELECT VERSION() AS version'
-  ], function(results){
+  ], function(error, results){
+    if(error) console.error(error);
     
     self.mysqlVersion = results[results.length - 1][0].version
       .split('-')[0]

--- a/test/helpers/querySequence.js
+++ b/test/helpers/querySequence.js
@@ -14,12 +14,12 @@ module.exports = function(connection, debug, queries, callback){
     return function(){
       debug && console.log('Query Sequence', index, queryStr);
       connection.query(queryStr, function(err, rows, fields){
-        if(err) throw err;
+        if(err) callback(err);
         results.push(rows);
         if(index < sequence.length - 1){
           sequence[index + 1]();
         }else{
-          callback(results);
+          callback(null, results);
         }
       });
     }

--- a/test/settings/mysql.js
+++ b/test/settings/mysql.js
@@ -5,6 +5,7 @@ module.exports = {
     host     : 'localhost',
     user     : 'root',
     password : 'numtel',
+    charset  : 'utf8mb4_unicode_ci',
     // debug: true
   },
   database: 'zongji_test'

--- a/test/types.js
+++ b/test/types.js
@@ -330,10 +330,10 @@ defineTypeTest('string', [
 defineTypeTest('text', [
   'TINYTEXT NULL',
   'MEDIUMTEXT NULL',
-  'LONGTEXT CHARACTER SET utf8 NULL',
+  'LONGTEXT NULL',
   'TEXT NULL'
 ], [
-  ['"something here"', '"tiny"', '"á"', '"binary"'],
+  ['"something here"', '"tiny"', '"a"', '"binary"'],
   ['"nothing there"', '"small"', '"b"', '"test123"'],
   [null, null, null, null]
 ]);

--- a/test/types.js
+++ b/test/types.js
@@ -62,7 +62,8 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion){
       ]);
 
     if(!minVersion || checkVersion(minVersion, conn.mysqlVersion)){
-      querySequence(conn.db, testQueries, function(results){
+      querySequence(conn.db, testQueries, function(error, results){
+        if(error) console.error(error);
         var selectResult = results[results.length - 1];
         var expectedWrite = {
           _type: 'WriteRows',
@@ -336,6 +337,13 @@ defineTypeTest('text', [
   ['"nothing there"', '"small"', '"b"', '"test123"'],
   [null, null, null, null]
 ]);
+
+defineTypeTest('utf8mb4', [
+  'VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci'
+], [
+  ['"á"'], // 3 byte character
+  ['"𠜎"'], // 4 byte character
+], '5.5.3');
 
 defineTypeTest('datetime_then_decimal', [
   'DATETIME(3) NULL',


### PR DESCRIPTION
In response to https://github.com/nevill/zongji/issues/37

* 4 byte test character errors when trying to insert value into field.
  Character copied from:
  http://www.i18nguy.com/unicode/supplementary-test.html
* querySequence test helper updated to output errors :facepalm:

@wj32 Any idea why I can't get that 4 byte character to insert into the database in this new test case? The first case with the 3 byte character works fine.

```
{ [Error: ER_TRUNCATED_WRONG_VALUE_FOR_FIELD: Incorrect string value: '\xF0\xA0\x9C\x8E' for column 'col0' at row 1]
  code: 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD',
  errno: 1366,
  sqlState: 'HY000',
  index: 0 }
```

Run the `utf8mb4` test case using this command:
```
./node_modules/nodeunit/bin/nodeunit test/types.js -t utf8mb4
```

---

Edit: Interesting, the results of [the Travis build](https://travis-ci.org/nevill/zongji/jobs/123609157) show that it seems to work on MySQL 5.5 but not 5.6. It wasn't working for me locally on 5.7. It works for me locally on 5.5.

There is no difference in [the documentation](https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html) between versions 5.5, 5.6, and 5.7.