### PR TITLE
Fixed the "PROTOCOL_CONNECTION_LOST" error

### DIFF
--- a/example.js
+++ b/example.js
@@ -18,6 +18,7 @@ zongji.start({
 
 process.on('SIGINT', function() {
   console.log('Got SIGINT.');
-  zongji.stop();
-  process.exit();
+  zongji.stop(function (err) {
+    process.exit();
+  });
 });

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ ZongJi.prototype.stop = function(callback){
     'KILL ' + self.connection.threadId,
     function(error, results){
       self.ctrlPool.end(function (err) {
-        callback(err);
+        callback && callback(err);
       });
     }
   );

--- a/index.js
+++ b/index.js
@@ -11,11 +11,10 @@ function ZongJi(dsn, options) {
   // to send table info query
   var ctrlDsn = cloneObjectSimple(dsn);
   ctrlDsn.database = 'information_schema';
-  this.ctrlConnection = mysql.createConnection(ctrlDsn);
-  this.ctrlConnection.on('error', this._emitError.bind(this));
-  this.ctrlConnection.on('unhandledError', this._emitError.bind(this));
+  this.ctrlPool = mysql.createPool(ctrlDsn);
+  this.ctrlPool.on('error', this._emitError.bind(this));
+  this.ctrlPool.on('unhandledError', this._emitError.bind(this));
 
-  this.ctrlConnection.connect();
   this.ctrlCallbacks = [];
 
   this.connection = mysql.createConnection(dsn);
@@ -96,10 +95,10 @@ ZongJi.prototype._init = function() {
 ZongJi.prototype._isChecksumEnabled = function(next) {
   var self = this;
   var sql = 'select @@GLOBAL.binlog_checksum as checksum';
-  var ctrlConnection = self.ctrlConnection;
+  var ctrlPool = self.ctrlPool;
   var connection = self.connection;
 
-  ctrlConnection.query(sql, function(err, rows) {
+  ctrlPool.query(sql, function(err, rows) {
     if (err) {
       if(err.toString().match(/ER_UNKNOWN_SYSTEM_VARIABLE/)){
         // MySQL < 5.6.2 does not support @@GLOBAL.binlog_checksum
@@ -134,7 +133,7 @@ ZongJi.prototype._isChecksumEnabled = function(next) {
 
 ZongJi.prototype._findBinlogEnd = function(next) {
   var self = this;
-  self.ctrlConnection.query('SHOW BINARY LOGS', function(err, rows) {
+  self.ctrlPool.query('SHOW BINARY LOGS', function(err, rows) {
     if (err) {
       // Errors should be emitted
       self.emit('error', err);
@@ -162,7 +161,7 @@ ZongJi.prototype._fetchTableInfo = function(tableMapEvent, next) {
   var sql = util.format(tableInfoQueryTemplate,
     tableMapEvent.schemaName, tableMapEvent.tableName);
 
-  this.ctrlConnection.query(sql, function(err, rows) {
+  this.ctrlPool.query(sql, function(err, rows) {
     if (err) {
       // Errors should be emitted
       self.emit('error', err);
@@ -230,14 +229,16 @@ ZongJi.prototype.start = function(options) {
   }
 };
 
-ZongJi.prototype.stop = function(){
+ZongJi.prototype.stop = function(callback){
   var self = this;
   // Binary log connection does not end with destroy()
   self.connection.destroy();
-  self.ctrlConnection.query(
+  self.ctrlPool.query(
     'KILL ' + self.connection.threadId,
-    function(error, reuslts){
-      self.ctrlConnection.destroy();
+    function(error, results){
+      self.ctrlPool.end(function (err) {
+        callback(err);
+      });
     }
   );
 };

--- a/test/errors.js
+++ b/test/errors.js
@@ -31,10 +31,8 @@ function generateDisconnectionCase(readyKillIdFun, cleanupKillIdFun) {
 
     function killThread(argFun) {
       var threadId = argFun(zongji);
-      if (threadId.getConnection) {
-        threadId.getConnection(function(err, connection) {
-          test.ok(!isNaN(connection.threadId));
-          conn.db.query('KILL ' + connection.threadId);
+      if (typeof threadId === 'object') {
+        threadId.end(function (err) {
           test.done();
         });
       } else {

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,4 +1,5 @@
 var ZongJi = require('./../');
+var Pool = require('mysql/lib/Pool');
 var getEventClass = require('./../lib/code_map').getEventClass;
 var settings = require('./settings/mysql');
 var connector =  require('./helpers/connector');
@@ -32,9 +33,8 @@ function generateDisconnectionCase(readyKillIdFun, cleanupKillIdFun) {
     function killThread(argFun) {
       var threadId = argFun(zongji);
       if (typeof threadId === 'object') {
-        threadId.end(function (err) {
-          test.done();
-        });
+        test.done();
+        threadId.end();
       } else {
         test.ok(!isNaN(threadId));
         conn.db.query('KILL ' + threadId);
@@ -75,9 +75,13 @@ module.exports = {
   binlogConnection_disconnect: generateDisconnectionCase(
     function onReady(zongji) { return zongji.connection.threadId },
     function onCleanup(zongji) { return zongji.ctrlPool }),
-  ctrlConnection_disconnect: generateDisconnectionCase(
+  ctrlPool_disconnect: generateDisconnectionCase(
     function onReady(zongji) { return zongji.ctrlPool },
     function onCleanup(zongji) { return zongji.connection.threadId }),
+  ctrlPool_prototype: function(test) {
+    test.ok(conn.zongji.ctrlPool instanceof Pool);
+    test.done();
+  },
   invalid_host: function(test) {
     var zongji = new ZongJi({
       host: 'wronghost',


### PR DESCRIPTION
How to reproduce error?

1. Open the terminal and print
```
user$ mysql -u root
mysql> set global wait_timeout=60 // Change the MySQL Timeout on a Server
mysql> quit
user$ node example.js
```
Now, after 60 seconds of idle the connection timeout will expire and the mysql server will close this connection and the process will die with the error
```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: Connection lost: The server closed the connection.
    at Protocol.end (/home/user/www/zongji/node_modules/mysql/lib/protocol/Protocol.js:109:13)
    at Socket.<anonymous> (/home/user/www/zongji/node_modules/mysql/lib/Connection.js:102:28)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:442:9)
    at process._tickCallback (node.js:356:17)
```
This problem was discussed in felixge/node-mysql#1268 and the collaborator of node-mysql recommends to solve this problem with the connection pool that I actually did.