### PR TITLE
ZongJi constructor accepts node-mysql Connection/Pool as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ For a complete implementation see [`example.js`](example.js)...
 
 ## ZongJi Class
 
-The `ZongJi` constructor accepts one argument: an object containg MySQL connection details in the same format as used by `node-mysql`.
+The `ZongJi` constructor accepts one argument of either:
+
+* An object containing MySQL connection details in the same format as used by `node-mysql`
+* Or, a `node-mysql` `Connection` or `Pool` object that will be used for querying column information.
+
+If a `Connection` or `Pool` object is passed to the constructor, it will not be destroyed/ended by Zongji's `stop()` method.
 
 Each instance includes the following methods:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zongji",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A mysql binlog listener running on Node.js",
   "main": "index.js",
   "directories": {
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "iconv-lite": "^0.4.13",
-    "mysql": "~2.12.0"
+    "mysql": "~2.13.0"
   }
 }


### PR DESCRIPTION
As a solution to multiple requests for allowing ZongJi to use a connection pool, (#59, and others...) I propose this patch which allows the constructor to accept an already instantiated `Connection` or `Pool` object to use for querying the column information. The binlog connection settings are then pulled from that object.

@nevill What do you think?

@vlasky This also has the updated `node-mysql` dependency.