### PR TITLE
mysql parser will use column charset as encoding when parsing strings

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -419,6 +419,11 @@ exports.readMysqlValue = function(parser, column, columnSchema, tableMap, emitte
       }else if(defPrefix === 'varbin'){
         result = parser.parseBuffer(size);
       }else{
+        if(column.charset !== null) {
+            // Javascript UTF8 always allows up to 4 bytes per character
+            column.charset = column.charset === 'utf8mb4' ? 'utf8' : column.charset;
+            parser._encoding = column.charset;
+        }
         result = parser.parseString(size);
       }
       break;


### PR DESCRIPTION
The mysql parser is hardcoded to use utf-8 by default when decoding strings. This causes garbled chars for varchar columns with a different collation (latin1 for example)