### PR TITLE
Dropp support MySQL 5.1, Node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ services:
   - docker
 before_script:
   - npm run lint
-  - docker pull mysql
-  - docker pull mtirsel/mysql-5.1
-  - docker run -p 3351:3306 --name mysql-51 -e MYSQL_ROOT_PASSWORD=numtel -d mtirsel/mysql-5.1 mysqld --datadir=/var/lib/mysql --user=mysql --server-id=1 --log-bin=/var/lib/mysql/mysql-bin.log --binlog-format=row
   - docker run -p 3355:3306 --name mysql-55 -e MYSQL_ROOT_PASSWORD=numtel -d mysql:5.5 --server-id=1 --log-bin=/var/lib/mysql/mysql-bin.log --binlog-format=row
   - docker run -p 3356:3306 --name mysql-56 -e MYSQL_ROOT_PASSWORD=numtel -d mysql:5.6 --server-id=1 --log-bin=/var/lib/mysql/mysql-bin.log --binlog-format=row
   - docker run -p 3357:3306 --name mysql-57 -e MYSQL_ROOT_PASSWORD=numtel -d mysql:5.7 --server-id=1 --log-bin=/var/lib/mysql/mysql-bin.log --binlog-format=row

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 sudo: required
 dist: trusty
 node_js:
-  - "0.10"
-  - "4.1"
+  - "4"
+  - "8"
 services:
   - mysql
   - docker

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For a complete implementation see [`example.js`](example.js)...
 
 ## Installation
 
-* Requires Node.js v0.10+
+* Requires Node.js v4+
 
   ```bash
   $ npm install zongji

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ZongJi (踪迹) is pronounced as `zōng jì` in Chinese.
 
 This package is a "pure JS" implementation based on [`node-mysql`](https://github.com/felixge/node-mysql). Since v0.2.0, The native part (which was written in C++) has been dropped.
 
-This package has been tested to work in MySQL 5.1, 5.5, 5.6, and 5.7. All MySQL server version greater than 5.1.14 are supported.
+This package has been tested to work in MySQL 5.5, 5.6, and 5.7.
 
 ## Quick Start
 

--- a/test/travis/runner.sh
+++ b/test/travis/runner.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-mysqlPorts=( 3351 3355 3356 3357 )
+mysqlPorts=( 3355 3356 3357 )
 sqlModes=( ANSI_QUOTES "" )
 dateString=( true false )
 for dateMode in "${dateString[@]}"; do


### PR DESCRIPTION
Since MySQL is End Of Life, we should support it anymore. The same to Node.js 0.10, instead, we add support to Node.js 8.