### PR TITLE
Fix passing Pool to Zongji constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function ZongJi(dsn, options) {
   // one connection to send table info query
   // Check first argument against possible connection objects
   for (var i = 0; i < alternateDsn.length; i++) {
-    if (dsn instanceof alternateDsn[i].type) {
+    if (dsn.constructor.name === alternateDsn[i].type.name) {
       this.ctrlConnection = dsn;
       this.ctrlConnectionOwner = false;
       binlogDsn = cloneObjectSimple(alternateDsn[i].config(dsn));


### PR DESCRIPTION
Currently, Zongji throws an error when passing a mysql `Pool` object to the constructor (see below). This PR fixes that.
Credit to @rodrigogs who fixed this in his fork (thanks!): https://github.com/rodrigogs/zongji/blob/master/index.js#L24

```
/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Parser.js:80
        throw err; // Rethrow non-MySQL errors
        ^

Error: ER_SPECIFIC_ACCESS_DENIED_ERROR: Access denied; you need (at least one of) the SUPER, REPLICATION CLIENT privilege(s) for this operation
    at Query.Sequence._packetToError (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Sequence.js:52:14)
    at Query.ErrorPacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Query.js:77:18)
    at Protocol._parsePacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Protocol.js:279:23)
    at Parser.write (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Parser.js:76:12)
    at Protocol.write (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Protocol.js:39:16)
    at Socket.<anonymous> (/path/to/node_modules/zongji/node_modules/mysql/lib/Connection.js:103:28)
    at Socket.emit (events.js:182:13)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at Socket.Readable.push (_stream_readable.js:219:10)
    --------------------
    at Protocol._enqueue (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Protocol.js:145:48)
    at Connection.query (/path/to/node_modules/zongji/node_modules/mysql/lib/Connection.js:208:25)
    at ZongJi._findBinlogEnd (/path/to/node_modules/zongji/index.js:169:23)
    at nextMethod (/path/to/node_modules/zongji/index.js:98:22)
    at /path/to/node_modules/zongji/index.js:102:9
    at Query._callback (/path/to/node_modules/zongji/index.js:159:9)
    at Query.Sequence.end (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Sequence.js:88:24)
    at Query._handleFinalResultPacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Query.js:139:8)
    at Query.OkPacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Query.js:72:10)
    at Protocol._parsePacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Protocol.js:279:23)
Emitted 'error' event at:
    at Query._callback (/path/to/node_modules/zongji/index.js:172:12)
    at Query.Sequence.end (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Sequence.js:88:24)
    at Query.ErrorPacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/sequences/Query.js:90:8)
    at Protocol._parsePacket (/path/to/node_modules/zongji/node_modules/mysql/lib/protocol/Protocol.js:279:23)
    [... lines matching original stack trace ...]
    at readableAddChunk (_stream_readable.js:264:11)
```