### PR TITLE
Fixed - User initialized options getting overridden bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ ZongJi.prototype._fetchTableInfo = function(tableMapEvent, next) {
 };
 
 ZongJi.prototype.set = function(options) {
-  this.options = options || {};
+  this.options = Object.assign(this.options || {}, options || {});;
 };
 
 ZongJi.prototype.start = function(options) {


### PR DESCRIPTION
# Bug Details
The user set options are getting overriden when options are set with internal `set` function call. 

# Fix
This fix merges the options' properties instead of replacing when set is invoked internally, so preserves the fields from user set options.