### PR TITLE
read inline for large objects

### DIFF
--- a/lib/json_decode.js
+++ b/lib/json_decode.js
@@ -42,7 +42,7 @@ module.exports = function(input) {
                                      UInt32LE)
  * @return Varies
  */
-function parseBinaryBuffer(input, offset, parentValueOffset, readUInt) {
+function parseBinaryBuffer(input, offset, parentValueOffset, readUInt, isLarge) {
   offset = offset || 0;
   readUInt = readUInt || input.readUInt16LE.bind(input);
 
@@ -104,11 +104,11 @@ function parseBinaryBuffer(input, offset, parentValueOffset, readUInt) {
       result = common.parseIEEE754Float(high, low);
       break;
     case JSONB_TYPE_INT32:
-      result = input.readInt32LE(valueOffset + 1);
+      result = isLarge ? input.readInt32LE(offset + 1) : input.readInt32LE(valueOffset + 1);
       break;
     case JSONB_TYPE_UINT32:
       // XXX: No known instance of this type being used
-      result = input.readUInt32LE(valueOffset + 1);
+      result = isLarge ? input.readUInt32LE(offset + 1) : input.readUInt32LE(valueOffset + 1);
       break;
     case JSONB_TYPE_INT64:
       low = input.readUInt32LE(valueOffset + 1);
@@ -264,7 +264,7 @@ function readObject(input, valueOffset, isLarge) {
     var memberValueOffset = memberValueStart + (pointerPos * (intSize + 1));
 
     result[thisKey] =
-      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt);
+      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt, isLarge);
   }
 
   return result;


### PR DESCRIPTION
Was getting a "range offset error" for these cases. I looked at this code: https://github.com/noplay/python-mysql-replication/blob/07e18b3c89f344db70cb968275ec0ef16d76d2cc/pymysqlreplication/packet.py#L41, and it seems we were missing a case.