### PR TITLE
handle changes in tablemap ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ ZongJi.prototype.start = function(options = {}) {
     switch (event.getTypeName()) {
       case 'TableMap': {
         const tableMap = this.tableMap[event.tableId];
-        if (!tableMap) {
+        if (!tableMap || tableMap.tableName !== event.tableName || tableMap.columns.length !== event.columnCount) {
           this.connection.pause();
           this._fetchTableInfo(event, () => {
             // merge the column info with metadata


### PR DESCRIPTION
It is possible that a tableMap event is passed from the MySQL protocol, that changes the id of a table. e.g.:

Current tablemap:
112: tableA
113: tableB

It's possible to get a tableMap event "113: tableA". Currently zongji doesn't handle this, because it sees we already have "113". With my proposed change, we check for changes in tableName or number of columns.

To fix the root cause, I'm wondering why we need to do a `_fetchTableInfo` anyway. What information do we retrieve in `_fetchTableInfo` that's not already included in the tableMap message?

If we don't need to do the `_fetchTableInfo`, we don't need to pause the connection, and we can just always use the latest tableMap event, as recommended by the replication protocol. Let me know if you have more info about this