### PR TITLE
Pass through isLarge to array members

### DIFF
--- a/lib/json_decode.js
+++ b/lib/json_decode.js
@@ -297,7 +297,7 @@ function readArray(input, valueOffset, isLarge) {
       (pointerPos * (1 + intSize)); // value type + value offset
 
     result.push(
-      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt));
+      parseBinaryBuffer(input, memberValueOffset, valueOffset, readUInt, isLarge));
   }
   return result;
 }


### PR DESCRIPTION
This was breaking several json fields.

(Related, JSON replication is also broken because this PR is still pending; https://github.com/nevill/zongji/pull/100)