### PR TITLE
MariaDB UUID support

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -75,6 +75,17 @@ exports.parseBytesArray = function(parser, length) {
   return result;
 };
 
+const parseUUID = (uuidBuffer) => {
+  const uuidHex = uuidBuffer.toString("hex");
+  return [
+    uuidHex.slice(0, 8),
+    uuidHex.slice(8, 12),
+    uuidHex.slice(12, 16),
+    uuidHex.slice(16, 20),
+    uuidHex.slice(20)
+  ].join("-");
+}
+
 // Parse column definition list string for SET and ENUM data types
 // @param type      String  Definition of column 'set(...)' or 'enum(...)'
 // @param prefixLen Integer Number of characters before list starts
@@ -422,8 +433,10 @@ exports.readMysqlValue = function(
         const bufsize = parseInt(def.substr(7, def.length - 2), 10);
         result = Buffer.alloc(bufsize, 0);
         parser.parseBuffer(size).copy(result);
-      } else if ((defPrefix === 'varbin') || (columnSchema.COLUMN_TYPE === "uuid")) {
+      } else if (defPrefix === 'varbin') {
         result = parser.parseBuffer(size);
+      } else if (columnSchema.COLUMN_TYPE === "uuid") {
+        result = parseUUID(parser.parseBuffer(size));
       } else {
         result = parser.parseString(size);
       }

--- a/lib/common.js
+++ b/lib/common.js
@@ -422,7 +422,7 @@ exports.readMysqlValue = function(
         const bufsize = parseInt(def.substr(7, def.length - 2), 10);
         result = Buffer.alloc(bufsize, 0);
         parser.parseBuffer(size).copy(result);
-      } else if (defPrefix === 'varbin') {
+      } else if ((defPrefix === 'varbin') || (columnSchema.COLUMN_TYPE === "uuid")) {
         result = parser.parseBuffer(size);
       } else {
         result = parser.parseString(size);


### PR DESCRIPTION
MariaDB support UUID type, which is stored in binary format. String conversion tampers the expected data, while the data in fact should hex encoded and (to match with the string interface to the column) split in segments.

This changes fix the issue for me, but invite to think about a cleaner/better approach. Consider this PR to be WIP and a request for feedback. Will keep this branch updated with better ideas.